### PR TITLE
plex: graceful shutdown + HTTP health probes to prevent DB::Exception crash loop

### DIFF
--- a/k8s/plex/library/templates/_statefulset.yaml
+++ b/k8s/plex/library/templates/_statefulset.yaml
@@ -31,6 +31,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "library.serviceAccountName" . }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -71,6 +74,10 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           startupProbe:
             {{- toYaml .Values.startupProbe | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/k8s/plex/plex/values.yaml
+++ b/k8s/plex/plex/values.yaml
@@ -187,14 +187,47 @@ initContainers:
       runAsUser: 1001
       runAsGroup: 1001
 
+# /identity is unauthenticated and only returns 200 once PMS has actually
+# opened its databases and is serving — a bare tcpSocket check passes while
+# PMS is crash-looping on a corrupt DB (which is how a dead PMS reported
+# Running and 502'd plex.drewburr.com).
 startupProbe:
-  tcpSocket:
+  httpGet:
+    path: /identity
     port: 32400
+  # Allow up to 5m for first start (large library / DB checkpoint on boot).
   failureThreshold: 30
   periodSeconds: 10
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /identity
     port: 32400
+  periodSeconds: 10
+  timeoutSeconds: 5
+  # Tolerate transient stalls under heavy transcode before forcing a restart.
+  failureThreshold: 5
 readinessProbe:
-  tcpSocket:
+  httpGet:
+    path: /identity
     port: 32400
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# PMS must checkpoint its SQLite WAL on shutdown. With the default 30s grace
+# period a busy server is SIGKILLed mid-write, leaving a huge inconsistent
+# WAL that PMS then refuses to open (DB::Exception crash loop). Give it time
+# to stop cleanly, and proactively signal + wait in a preStop hook.
+terminationGracePeriodSeconds: 120
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/bash
+        - -c
+        - >-
+          pkill -TERM -f 'Plex Media Server' || true;
+          for i in $(seq 1 110); do
+          pgrep -f 'Plex Media Server' >/dev/null 2>&1 || exit 0;
+          sleep 1;
+          done


### PR DESCRIPTION
## What happened

`plex.drewburr.com` started returning **502**. The pod showed `1/1 Running`, but Plex Media Server was crash-looping *inside* the container:

```
Error: Unable to set up server: std::exception (N2DB9ExceptionE)
```

`N2DB9ExceptionE` demangles to `DB::Exception` — PMS could not open its library SQLite database.

### Root cause: abrupt shutdown corrupted the WAL

The pod was recreated ~97m before the outage. The kubelet events show *why* it was unclean:

```
Warning  FailedKillPod  pod/plex-plex-0  error killing pod:
  failed to "KillContainer" for "plex": DeadlineExceeded context deadline exceeded
  failed to "KillPodSandbox": DeadlineExceeded
```

PMS does not stop within the **default 30s `terminationGracePeriodSeconds`**, so containerd's kill deadline was exceeded and PMS was **SIGKILLed mid-write**. It never checkpointed its SQLite write-ahead log, leaving a **128 MB inconsistent `com.plexapp.plugins.library.db-wal`** (only ~741 valid frames; `wal_checkpoint` returned `SQLITE_BUSY`). On restart PMS tried a full checkpoint, hit the corrupt WAL tail, threw `DB::Exception`, and crash-looped.

The outage was invisible to Kubernetes because the **`tcpSocket:32400` liveness/readiness probes** passed each time the port briefly opened during the crash loop — so the Service simply had no healthy backend and nginx returned 502.

The live database was already recovered out-of-band (`VACUUM INTO` a fresh WAL-free DB; corrupt original preserved on the `backups` PVC). **This PR prevents recurrence.**

## Changes

- **`library` chart** (`_statefulset.yaml`): add optional, `with`-guarded `terminationGracePeriodSeconds` (pod) and `lifecycle` (container) passthrough. No-op when unset → backward-compatible for the other apps sharing this chart.
- **`plex` values**: `terminationGracePeriodSeconds` 30 → **120**, plus a `preStop` hook that SIGTERMs PMS and waits up to 110s for it to exit — so the WAL is checkpointed during a normal shutdown instead of being SIGKILLed.
- **`plex` values**: liveness/readiness/startup probes `tcpSocket` → **`httpGet /identity`** (unauthenticated, only returns 200 once PMS has opened its DBs and is serving). Liveness `failureThreshold: 5` to tolerate transient stalls under heavy transcode.

## Validation

`helm dependency build` + `helm template` renders valid YAML with `terminationGracePeriodSeconds: 120`, the `preStop` exec hook, and `httpGet: /identity` on all three probes.

## Deploy note

This is a GitOps repo; `plex-plex` has no ArgoCD auto-sync. After merge, **sync the `plex-plex` app in ArgoCD** to roll the StatefulSet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)