### PR TITLE
k8s: scale down to 2 replicas for kube04 decommission

### DIFF
--- a/k8s/argocd/values.yaml
+++ b/k8s/argocd/values.yaml
@@ -12,6 +12,8 @@ argocd:
 
   redis-ha:
     enabled: true
+    # Sentinel quorum needs 3; with 2 worker nodes, soft anti-affinity lets two pods co-locate.
+    hardAntiAffinity: false
     metrics:
       enabled: true
     redis:
@@ -23,6 +25,7 @@ argocd:
           cpu: 500m
           memory: 100Mi
     haproxy:
+      hardAntiAffinity: false
       resources:
         limits:
           cpu: 250m
@@ -44,7 +47,7 @@ argocd:
         memory: 256Mi
 
   server:
-    replicas: 3
+    replicas: 2
     metrics:
       enabled: true
     resources:

--- a/k8s/loki/values.yaml
+++ b/k8s/loki/values.yaml
@@ -30,6 +30,8 @@ loki:
       max_concurrent: 4
 
     commonConfig:
+      # Match write replica count; default 3 would fail quorum with only 2 writers.
+      replication_factor: 2
       ring:
         kvstore:
           # Backend storage to use for the ring
@@ -39,14 +41,14 @@ loki:
   deploymentMode: SimpleScalable
 
   backend:
-    replicas: 3
+    replicas: 2
     persistence:
       size: 10Gi
       storageClass: zfs-nvmeof
   read:
-    replicas: 3
+    replicas: 2
   write:
-    replicas: 3
+    replicas: 2
     persistence:
       size: 50Gi
       storageClass: zfs-nvmeof


### PR DESCRIPTION
## Summary
- Loki backend/read/write 3→2 with `commonConfig.replication_factor: 2` so writes keep quorum with 2 ingesters.
- ArgoCD server 3→2 (stateless).
- ArgoCD redis-ha kept at 3 for Sentinel quorum; `hardAntiAffinity: false` on redis and haproxy so pods can co-locate across the remaining 2 worker nodes.

## Test plan
- [ ] ArgoCD sync of `loki` and `argocd` apps after merge
- [ ] Confirm all loki-write/read/backend pods Ready; check `loki_ingester_*` and write path via Grafana
- [ ] Confirm argocd-server has 2 Ready replicas and UI/ingress works
- [ ] Confirm redis-ha statefulset reaches 3/3 with kube04 cordoned (pods co-locating as expected)
- [ ] Clean up orphaned `*-2` PVCs for loki write/backend after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)