### PR TITLE
grafana: set root_url to public HTTPS host

### DIFF
--- a/k8s/prometheus/values.yaml
+++ b/k8s/prometheus/values.yaml
@@ -83,6 +83,9 @@ kube-prometheus-stack:
     # https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#override-configuration-with-environment-variables
     env:
       GF_AUTH_ANONYMOUS_ENABLED: true
+      # Ensures alert notification/deeplink URLs use the public HTTPS host
+      # instead of the default http://<host>:3000
+      GF_SERVER_ROOT_URL: https://grafana.drewburr.com
 
     ingress:
       enabled: true


### PR DESCRIPTION
Alert notification and deeplink URLs were rendering as `http://grafana.drewburr.com:3000` because no server `root_url` was configured, so Grafana defaulted to the pod host + port.

Sets `GF_SERVER_ROOT_URL` to `https://grafana.drewburr.com` so all external links (Discord alert notifications, deeplinks, share URLs) resolve over HTTPS with no port.

Takes effect after ArgoCD sync (Grafana pod restarts to pick up the env var).