### PR TITLE
Add Tautulli + Maintainerr for hardlink-safe media cleanup

### DIFF
--- a/k8s/plex/maintainerr/.helmignore
+++ b/k8s/plex/maintainerr/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/maintainerr/Chart.yaml
+++ b/k8s/plex/maintainerr/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: maintainerr
+description: A Helm chart for deploying maintainerr
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/maintainerr/templates/_helpers.tpl
+++ b/k8s/plex/maintainerr/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "maintainerr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "maintainerr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "maintainerr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "maintainerr.labels" -}}
+helm.sh/chart: {{ include "maintainerr.chart" . }}
+{{ include "maintainerr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "maintainerr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "maintainerr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "maintainerr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "maintainerr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/maintainerr/templates/deployment.yaml
+++ b/k8s/plex/maintainerr/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "maintainerr.deployment") -}}
+{{- define "maintainerr.deployment" -}}
+{{- end -}}

--- a/k8s/plex/maintainerr/templates/hardlink-guard-cronjob.yaml
+++ b/k8s/plex/maintainerr/templates/hardlink-guard-cronjob.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.hardlinkGuard.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "maintainerr.fullname" . }}-hardlink-guard
+  labels:
+    {{- include "maintainerr.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.hardlinkGuard.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            {{- include "maintainerr.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsUser: 1001
+            runAsGroup: 1001
+            fsGroup: 1001
+          containers:
+            - name: hardlink-guard
+              image: {{ .Values.hardlinkGuard.image | quote }}
+              env:
+                - name: LIBRARY_PATH
+                  value: {{ .Values.hardlinkGuard.libraryPath | quote }}
+                - name: EXCLUDE_PATH
+                  value: {{ .Values.hardlinkGuard.excludePath | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache findutils coreutils >/dev/null
+
+                  ts="$(date +%Y-%m-%dT%H-%M-%S)"
+                  outdir="/backups/hardlink-guard"
+                  mkdir -p "$outdir"
+                  safe="$outdir/reclaimable-${ts}.txt"
+                  prot="$outdir/protected-${ts}.txt"
+
+                  # SAFE: link count == 1 -> deleting actually frees space.
+                  # PROTECTED: link count > 1 -> hardlinked (likely a seeding
+                  # torrent); deletion frees nothing, so never remove these.
+                  find "$LIBRARY_PATH" -type f -links 1  -not -path "${EXCLUDE_PATH}/*" > "$safe"  || true
+                  find "$LIBRARY_PATH" -type f -links +1 -not -path "${EXCLUDE_PATH}/*" > "$prot"  || true
+
+                  safe_n="$(wc -l < "$safe" | tr -d ' ')"
+                  prot_n="$(wc -l < "$prot" | tr -d ' ')"
+                  safe_b="$(find "$LIBRARY_PATH" -type f -links 1 -not -path "${EXCLUDE_PATH}/*" -printf '%s\n' | awk '{s+=$1} END{print s+0}')"
+
+                  echo "==================== hardlink-guard @ ${ts} ===================="
+                  echo "library path      : $LIBRARY_PATH  (excluding ${EXCLUDE_PATH})"
+                  echo "reclaimable files : $safe_n  ($(numfmt --to=iec "$safe_b") if deleted)"
+                  echo "protected files   : $prot_n  (hardlinked -> deleting frees nothing)"
+                  echo "reports written   : $safe"
+                  echo "                    $prot"
+                  echo "NOTE: audit only -- this job never deletes. Feed the"
+                  echo "reclaimable list into Maintainerr / arr for actual cleanup."
+              volumeMounts:
+                - name: plex-data
+                  mountPath: /data
+                  readOnly: true
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: plex-data
+              persistentVolumeClaim:
+                claimName: plex-data
+            - name: backups
+              persistentVolumeClaim:
+                claimName: backups
+{{- end }}

--- a/k8s/plex/maintainerr/templates/ingress.yaml
+++ b/k8s/plex/maintainerr/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/maintainerr/templates/pvc.yaml
+++ b/k8s/plex/maintainerr/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/maintainerr/templates/service.yaml
+++ b/k8s/plex/maintainerr/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/maintainerr/templates/serviceaccount.yaml
+++ b/k8s/plex/maintainerr/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "maintainerr.serviceaccount") -}}
+{{- end -}}
+{{- define "maintainerr.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/maintainerr/values.yaml
+++ b/k8s/plex/maintainerr/values.yaml
@@ -1,0 +1,106 @@
+# https://docs.maintainerr.info/
+# Rules-based media cleanup: builds collections from Plex/Tautulli/Radarr/Sonarr/
+# Overseerr rules, shows candidates, then deletes after a grace period.
+# Deletes are routed THROUGH Radarr/Sonarr so torrents can keep seeding.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/jorenn92/maintainerr
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+# Maintainerr does not use PUID/PGID; run as the media uid/gid directly.
+podSecurityContext:
+  runAsUser: 1001
+  runAsGroup: 1001
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext: {}
+
+services:
+  - name: http
+    type: ClusterIP
+    port: 6246
+    protocol: TCP
+    ingress:
+      className: nginx-internal
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      hosts:
+        - host: maintainerr.drewburr.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+      - secretName: maintainerr-ingress
+        hosts:
+          - maintainerr.drewburr.com
+
+resources: {}
+
+env: []
+
+envVars:
+  TZ: America/New_York
+
+# Maintainerr stores its SQLite DB + config under /opt/data.
+persistence:
+  - name: maintainerr-config
+    mountPath: opt/data
+    accessModes:
+      - ReadWriteOnce
+    requests: 5Gi
+    storageClassName: zfs-nvmeof
+  - name: backups
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+startupProbe:
+  httpGet:
+    path: /
+    port: 6246
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet:
+    path: /
+    port: 6246
+readinessProbe:
+  httpGet:
+    path: /
+    port: 6246
+
+# ---------------------------------------------------------------------------
+# Hardlink-safety audit CronJob (see templates/hardlink-guard-cronjob.yaml).
+# Scans the shared plex-data library and reports which files are genuinely
+# safe to reclaim (link count == 1) vs. protected (hardlinked, count > 1 --
+# deleting frees no space and would need the torrent kept for seeding).
+# This is scoped to plex-data ONLY; the alt/private ecosystem lives on the
+# separate plex-alt-data volume and is never touched here.
+# ---------------------------------------------------------------------------
+hardlinkGuard:
+  enabled: true
+  schedule: "0 6 * * *"   # daily 06:00
+  image: alpine:3.20
+  # Path inside the container to scan (plex-data mounted at /data).
+  libraryPath: /data/media
+  # Subtree(s) to skip so we don't list the torrent seed copies themselves.
+  # Adjust to your actual download root under plex-data.
+  excludePath: /data/torrents

--- a/k8s/plex/tautulli/.helmignore
+++ b/k8s/plex/tautulli/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/tautulli/Chart.yaml
+++ b/k8s/plex/tautulli/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: tautulli
+description: A Helm chart for deploying tautulli
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/tautulli/templates/_helpers.tpl
+++ b/k8s/plex/tautulli/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tautulli.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tautulli.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "tautulli.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "tautulli.labels" -}}
+helm.sh/chart: {{ include "tautulli.chart" . }}
+{{ include "tautulli.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "tautulli.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tautulli.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "tautulli.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "tautulli.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/tautulli/templates/deployment.yaml
+++ b/k8s/plex/tautulli/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "tautulli.deployment") -}}
+{{- define "tautulli.deployment" -}}
+{{- end -}}

--- a/k8s/plex/tautulli/templates/ingress.yaml
+++ b/k8s/plex/tautulli/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/tautulli/templates/pvc.yaml
+++ b/k8s/plex/tautulli/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/tautulli/templates/service.yaml
+++ b/k8s/plex/tautulli/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/tautulli/templates/serviceaccount.yaml
+++ b/k8s/plex/tautulli/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "tautulli.serviceaccount") -}}
+{{- end -}}
+{{- define "tautulli.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/tautulli/values.yaml
+++ b/k8s/plex/tautulli/values.yaml
@@ -1,0 +1,92 @@
+# https://hotio.dev/containers/tautulli/
+replicaCount: 1
+
+image:
+  repository: ghcr.io/hotio/tautulli
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext: {}
+
+# Ports to be exposed, grouped by services
+services:
+  - name: http
+    type: ClusterIP
+    port: 8181
+    protocol: TCP
+    ingress:
+      className: nginx-internal
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      hosts:
+        - host: tautulli.drewburr.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+      - secretName: tautulli-ingress
+        hosts:
+          - tautulli.drewburr.com
+
+resources: {}
+
+# Appended to env. Supports envFrom
+env: []
+
+# Key: value environment variables to be appended to env
+envVars:
+  PUID: 1001
+  PGID: 1001
+  TZ: America/New_York
+
+# All are mounted under fsroot `/`. Supports additions
+# Only a config PVC is needed; Tautulli talks to Plex over the network API.
+persistence:
+  - name: tautulli-config
+    mountPath: config
+    accessModes:
+      - ReadWriteOnce
+    requests: 10Gi
+    storageClassName: zfs-nvmeof
+  - name: backups
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+startupProbe:
+  httpGet:
+    path: /
+    port: 8181
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet:
+    path: /
+    port: 8181
+readinessProbe:
+  httpGet:
+    path: /
+    port: 8181


### PR DESCRIPTION
## What

Two new `plex`-namespace apps (auto-discovered by the `drewburr-namespaced-apps` ApplicationSet):

- **tautulli** — Plex watch-history source of truth. `ghcr.io/hotio/tautulli`, port 8181, `tautulli.drewburr.com`, config PVC only (uses the Plex API).
- **maintainerr** — rules-based cleanup engine. `ghcr.io/jorenn92/maintainerr`, port 6246, `maintainerr.drewburr.com`, SQLite config PVC at `/opt/data`.

Both follow the existing `sonarr`/`radarr` chart pattern (thin wrapper over the shared `library` subchart), verified with `helm template`.

## Hardlink safety

`maintainerr/templates/hardlink-guard-cronjob.yaml` runs a **daily audit that never deletes**. It mounts `plex-data` read-only and splits the library:

- **reclaimable** — link count 1, deleting actually frees space
- **protected** — link count > 1, hardlinked (seeding torrent) → deleting frees nothing

Reports are written to the `backups` volume. Scoped to `plex-data` only; the private/alt ecosystem on `plex-alt-data` (`qbittorrent-alt` + `sonarr-alt`) is never touched.

## Follow-ups (configured in the UIs, not Git)

- [ ] Set `hardlinkGuard.libraryPath` / `excludePath` to the real paths under `plex-data` (defaults: `/data/media`, `/data/torrents`).
- [ ] Wire Maintainerr → Radarr/Sonarr so deletes route through the *arr and keep torrents seeding; scope rules to the `plex-data`-backed libraries.