### PR TITLE
Fix hardlink-guard: use debian:stable-slim, drop apk install

### DIFF
--- a/k8s/plex/maintainerr/templates/hardlink-guard-cronjob.yaml
+++ b/k8s/plex/maintainerr/templates/hardlink-guard-cronjob.yaml
@@ -36,7 +36,6 @@ spec:
                 - -c
                 - |
                   set -eu
-                  apk add --no-cache findutils coreutils >/dev/null
 
                   ts="$(date +%Y-%m-%dT%H-%M-%S)"
                   outdir="/backups/hardlink-guard"

--- a/k8s/plex/maintainerr/values.yaml
+++ b/k8s/plex/maintainerr/values.yaml
@@ -98,7 +98,7 @@ readinessProbe:
 hardlinkGuard:
   enabled: true
   schedule: "0 6 * * *"   # daily 06:00
-  image: alpine:3.20
+  image: debian:stable-slim
   # Path inside the container to scan (plex-data mounted at /data).
   libraryPath: /data/media
   # Subtree(s) to skip so we don't list the torrent seed copies themselves.


### PR DESCRIPTION
The hardlink-guard CronJob runs as uid 1001, so `apk add` failed with permission denied on every daily run since deploy — no audit reports were ever written. Switch the job image to `debian:stable-slim`, which already ships findutils/coreutils/awk, and drop the install step. Script is otherwise unchanged.