### PR TITLE
Remove Maintainerr ingress (unauthenticated API exposes credentials)

### DIFF
--- a/k8s/plex/maintainerr/values.yaml
+++ b/k8s/plex/maintainerr/values.yaml
@@ -35,19 +35,6 @@ services:
     type: ClusterIP
     port: 6246
     protocol: TCP
-    ingress:
-      className: nginx-internal
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-      hosts:
-        - host: maintainerr.drewburr.com
-          paths:
-            - path: /
-              pathType: ImplementationSpecific
-      tls:
-      - secretName: maintainerr-ingress
-        hosts:
-          - maintainerr.drewburr.com
 
 resources: {}
 


### PR DESCRIPTION
Maintainerr has no built-in auth; its /api/settings endpoint returns the Plex auth token and Radarr/Sonarr/Tautulli API keys to anyone who can reach it. Remove the nginx-internal ingress — use `kubectl port-forward -n plex svc/plex-maintainerr-http 6246:6246` for access. Recommend rotating the exposed keys after merge.