### PR TITLE
Maintainerr: switch to maintained image repo

### DIFF
--- a/k8s/plex/maintainerr/values.yaml
+++ b/k8s/plex/maintainerr/values.yaml
@@ -6,10 +6,10 @@ replicaCount: 1
 
 image:
   # Development moved from jorenn92/maintainerr (frozen at 2.19.0) to the
-  # maintainerr org; pin the tag so upgrades are explicit git changes.
+  # maintainerr org.
   repository: ghcr.io/maintainerr/maintainerr
-  pullPolicy: IfNotPresent
-  tag: "3.21.1"
+  pullPolicy: Always
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/k8s/plex/maintainerr/values.yaml
+++ b/k8s/plex/maintainerr/values.yaml
@@ -5,10 +5,11 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/jorenn92/maintainerr
-  pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  # Development moved from jorenn92/maintainerr (frozen at 2.19.0) to the
+  # maintainerr org; pin the tag so upgrades are explicit git changes.
+  repository: ghcr.io/maintainerr/maintainerr
+  pullPolicy: IfNotPresent
+  tag: "3.21.1"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
`ghcr.io/jorenn92/maintainerr` is frozen at 2.19.0 — its `latest` tag no longer advances. Development moved to `ghcr.io/maintainerr/maintainerr` (currently 3.21.1). Track `latest` there with pullPolicy Always.