### PR TITLE
seeding-guard: drop fsGroup (recursive chown stalled pod start)

### DIFF
--- a/k8s/plex/maintainerr/templates/seeding-guard-cronjob.yaml
+++ b/k8s/plex/maintainerr/templates/seeding-guard-cronjob.yaml
@@ -19,10 +19,11 @@ spec:
             {{- include "maintainerr.selectorLabels" . | nindent 12 }}
         spec:
           restartPolicy: Never
+          # Run as the media uid/gid directly; no fsGroup -- it would make the
+          # kubelet recursively chown the entire plex-data volume every mount.
           securityContext:
             runAsUser: 1001
             runAsGroup: 1001
-            fsGroup: 1001
           containers:
             - name: seeding-guard
               image: {{ .Values.seedingGuard.image | quote }}


### PR DESCRIPTION
`fsGroup: 1001` triggers a kubelet recursive chown/chmod of the whole plex-data volume at mount time (observed: 'Setting volume ownership ... is taking longer than expected'). Files are already owned by 1001; `runAsUser`/`runAsGroup` are sufficient. Same fix is applied to PR #12's missing-cleanup job.