### PR TITLE
Guard jobs: source Plex token from shared-secrets (Maintainerr 3.x masks it)

### DIFF
--- a/k8s/plex/maintainerr/templates/seeding-guard-cronjob.yaml
+++ b/k8s/plex/maintainerr/templates/seeding-guard-cronjob.yaml
@@ -28,8 +28,13 @@ spec:
             - name: seeding-guard
               image: {{ .Values.seedingGuard.image | quote }}
               env:
-                - name: MAINTAINERR_URL
-                  value: http://{{ include "maintainerr.fullname" . }}-http:{{ (index .Values.services 0).port }}
+                - name: PLEX_URL
+                  value: {{ .Values.seedingGuard.plexUrl | quote }}
+                - name: PLEX_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: plex-token
+                      key: token
                 - name: LIBRARY_PATH
                   value: {{ .Values.seedingGuard.libraryPath | quote }}
                 - name: SEED_LABEL

--- a/k8s/plex/maintainerr/templates/seeding-guard-script.yaml
+++ b/k8s/plex/maintainerr/templates/seeding-guard-script.yaml
@@ -16,14 +16,14 @@ data:
     so labeled media can never be matched for cleanup. This script only ever
     edits Plex labels; it never deletes anything.
     """
-    import json
     import os
     import sys
     import urllib.parse
     import urllib.request
     import xml.etree.ElementTree as ET
 
-    MAINTAINERR_URL = os.environ["MAINTAINERR_URL"]
+    PLEX_URL = os.environ["PLEX_URL"]
+    token = os.environ["PLEX_TOKEN"]
     LIBRARY_PATH = os.environ["LIBRARY_PATH"]
     SEED_LABEL = os.environ.get("SEED_LABEL", "seeding")
     REPORT_DIR = os.environ.get("REPORT_DIR", "/backups/seeding-guard")
@@ -33,12 +33,7 @@ data:
         with urllib.request.urlopen(req, timeout=60) as res:
             return res.read()
 
-    # Plex connection details come from Maintainerr's own settings, so there
-    # is no separate token secret to manage.
-    settings = json.loads(fetch(MAINTAINERR_URL + "/api/settings"))
-    scheme = "https" if settings["plex_ssl"] else "http"
-    plex = f'{scheme}://{settings["plex_hostname"]}:{settings["plex_port"]}'
-    token = settings["plex_auth_token"]
+    plex = PLEX_URL.rstrip("/")
 
     def plex_get(path, **params):
         params["X-Plex-Token"] = token

--- a/k8s/plex/maintainerr/values.yaml
+++ b/k8s/plex/maintainerr/values.yaml
@@ -91,6 +91,9 @@ seedingGuard:
   image: python:3.12-slim
   # Plex label applied to seeding media; must match the Maintainerr rule guard.
   label: seeding
+  # Plex URL for direct API access; token comes from the plex-token secret
+  # (projected by the ExternalSecret in the plex chart).
+  plexUrl: http://plex-plex-https:32400
   # Library root inside the container (plex-data mounted at /data, same paths
   # Plex itself reports).
   libraryPath: /data/media

--- a/k8s/plex/plex/templates/missing-cleanup-cronjob.yaml
+++ b/k8s/plex/plex/templates/missing-cleanup-cronjob.yaml
@@ -28,8 +28,13 @@ spec:
             - name: missing-cleanup
               image: {{ .Values.missingCleanup.image | quote }}
               env:
-                - name: MAINTAINERR_URL
-                  value: {{ .Values.missingCleanup.maintainerrUrl | quote }}
+                - name: PLEX_URL
+                  value: {{ .Values.missingCleanup.plexUrl | quote }}
+                - name: PLEX_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: plex-token
+                      key: token
                 - name: LIBRARY_PATH
                   value: {{ .Values.missingCleanup.libraryPath | quote }}
                 - name: DRY_RUN

--- a/k8s/plex/plex/templates/missing-cleanup-script.yaml
+++ b/k8s/plex/plex/templates/missing-cleanup-script.yaml
@@ -20,14 +20,14 @@ data:
     <mediaId>): the file is already gone, so nothing is removed from disk, and
     other intact versions of the same item are untouched.
     """
-    import json
     import os
     import sys
     import urllib.parse
     import urllib.request
     import xml.etree.ElementTree as ET
 
-    MAINTAINERR_URL = os.environ["MAINTAINERR_URL"]
+    PLEX_URL = os.environ["PLEX_URL"]
+    token = os.environ["PLEX_TOKEN"]
     LIBRARY_PATH = os.environ["LIBRARY_PATH"]
     DRY_RUN = os.environ.get("DRY_RUN", "false").lower() == "true"
     MAX_MISSING_PERCENT = float(os.environ.get("MAX_MISSING_PERCENT", "10"))
@@ -37,10 +37,7 @@ data:
         with urllib.request.urlopen(req, timeout=60) as res:
             return res.read()
 
-    settings = json.loads(fetch(MAINTAINERR_URL + "/api/settings"))
-    scheme = "https" if settings["plex_ssl"] else "http"
-    plex = f'{scheme}://{settings["plex_hostname"]}:{settings["plex_port"]}'
-    token = settings["plex_auth_token"]
+    plex = PLEX_URL.rstrip("/")
 
     def plex_get(path, **params):
         params["X-Plex-Token"] = token

--- a/k8s/plex/plex/templates/plex-token-externalsecret.yaml
+++ b/k8s/plex/plex/templates/plex-token-externalsecret.yaml
@@ -1,0 +1,28 @@
+# Projects the manually-created `plex-token` secret from shared-secrets into
+# the plex namespace (Maintainerr 3.x masks secrets in its settings API, so
+# the guard/cleanup CronJobs can no longer read the token from there).
+#
+# Source secret (one-time, value git-ignored by convention):
+#   kubectl create secret generic plex-token -n shared-secrets \
+#     --from-literal=token=<X-Plex-Token>
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: plex-token
+  labels:
+    {{- include "plex.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: shared-secrets
+    kind: ClusterSecretStore
+  target:
+    name: plex-token
+  data:
+    - secretKey: token
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: plex-token
+        metadataPolicy: None
+        property: token

--- a/k8s/plex/plex/values.yaml
+++ b/k8s/plex/plex/values.yaml
@@ -257,14 +257,14 @@ lifecycle:
 # entries whose file no longer exists on disk (checked by stat() on the
 # read-only plex-data mount, never HTTP probes). A circuit breaker aborts
 # without deleting if more than maxMissingPercent of the library looks
-# missing (mount/scan problem, not routine cleanup). Plex credentials are
-# read from Maintainerr's settings API at runtime.
+# missing (mount/scan problem, not routine cleanup). The Plex token comes
+# from the plex-token secret (ExternalSecret <- shared-secrets/plex-token).
 # ---------------------------------------------------------------------------
 missingCleanup:
   enabled: true
   schedule: "30 6 * * *"   # daily 06:30, after the seeding-guard
   image: python:3.12-slim
-  maintainerrUrl: http://plex-maintainerr-http:6246
+  plexUrl: http://plex-plex-https:32400
   libraryPath: /data/media
   # Set true to only report what would be removed.
   dryRun: false


### PR DESCRIPTION
Both test jobs failed with 401: Maintainerr 3.x masks secrets in `/api/settings` (2.x returned them in cleartext — the design was built and only ever validated against 2.19).

- New ExternalSecret in the plex chart projects `shared-secrets/plex-token` into the plex namespace.
- Both CronJobs take `PLEX_TOKEN` from that secret and `PLEX_URL` from values; the Maintainerr API dependency is gone.

**One-time manual step before sync** (token from Plex Web: any item → Get Info → View XML → `X-Plex-Token` in the URL):
```
kubectl create secret generic plex-token -n shared-secrets --from-literal=token=<X-Plex-Token>
```