### PR TITLE
Guard job pods must not match Service selectors (root cause of cleanup failures)

### DIFF
--- a/k8s/plex/maintainerr/templates/seeding-guard-cronjob.yaml
+++ b/k8s/plex/maintainerr/templates/seeding-guard-cronjob.yaml
@@ -15,8 +15,12 @@ spec:
       backoffLimit: 1
       template:
         metadata:
+          # Deliberately NOT the chart selectorLabels: those would match the
+          # Service selector and make kube-proxy load-balance service traffic
+          # to this job pod (instant connection-refused for callers).
           labels:
-            {{- include "maintainerr.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/name: {{ include "maintainerr.name" . }}-seeding-guard
+            app.kubernetes.io/instance: {{ .Release.Name }}
         spec:
           restartPolicy: Never
           # Run as the media uid/gid directly; no fsGroup -- it would make the

--- a/k8s/plex/plex/templates/missing-cleanup-cronjob.yaml
+++ b/k8s/plex/plex/templates/missing-cleanup-cronjob.yaml
@@ -15,8 +15,13 @@ spec:
       backoffLimit: 1
       template:
         metadata:
+          # Deliberately NOT the chart selectorLabels: those would match the
+          # plex-plex-https Service selector and make kube-proxy load-balance
+          # Plex traffic to this job pod (instant connection-refused — this is
+          # exactly what broke the first missing-cleanup runs).
           labels:
-            {{- include "plex.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/name: {{ include "plex.name" . }}-missing-cleanup
+            app.kubernetes.io/instance: {{ .Release.Name }}
         spec:
           restartPolicy: Never
           # Run as the media uid/gid directly; no fsGroup -- it would make the


### PR DESCRIPTION
The CronJob pod templates stamped job pods with the charts' `selectorLabels`, so whenever a guard/cleanup pod was Running, kube-proxy added it as an endpoint of the corresponding Service (`plex-plex-https` for missing-cleanup, the maintainerr service for seeding-guard). Traffic — including the job's own Plex API calls — then round-robined onto a pod with nothing listening: instant connection refused.

This explains all observed failures: refusals only while a job pod was alive, the round-1 run dying mid-deletes when its retry pod appeared, the apparent kube03 correlation (just where jobs scheduled), and Plex never restarting.

Fix: distinct `app.kubernetes.io/name` per job (`plex-missing-cleanup`, `maintainerr-seeding-guard`) so no Service selector matches.