### PR TITLE
Books stack: calibre-web / shelfmark / bookshelf

### DIFF
--- a/k8s/plex/bookshelf/.helmignore
+++ b/k8s/plex/bookshelf/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/bookshelf/Chart.yaml
+++ b/k8s/plex/bookshelf/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: bookshelf
+description: A Helm chart for deploying Bookshelf (Readarr fork)
+type: application
+version: 0.1.0
+appVersion: "hardcover"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/bookshelf/templates/_helpers.tpl
+++ b/k8s/plex/bookshelf/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bookshelf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bookshelf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bookshelf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bookshelf.labels" -}}
+helm.sh/chart: {{ include "bookshelf.chart" . }}
+{{ include "bookshelf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bookshelf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bookshelf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bookshelf.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bookshelf.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/bookshelf/templates/deployment.yaml
+++ b/k8s/plex/bookshelf/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "bookshelf.deployment") -}}
+{{- define "bookshelf.deployment" -}}
+{{- end -}}

--- a/k8s/plex/bookshelf/templates/ingress.yaml
+++ b/k8s/plex/bookshelf/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/bookshelf/templates/pvc.yaml
+++ b/k8s/plex/bookshelf/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/bookshelf/templates/service.yaml
+++ b/k8s/plex/bookshelf/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/bookshelf/templates/serviceaccount.yaml
+++ b/k8s/plex/bookshelf/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "bookshelf.serviceaccount") -}}
+{{- end -}}
+{{- define "bookshelf.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/bookshelf/values.yaml
+++ b/k8s/plex/bookshelf/values.yaml
@@ -1,0 +1,115 @@
+# https://github.com/pennydreadful/bookshelf
+# Readarr fork for monitored-author grabs via the existing qbittorrent and
+# sabnzbd deployments. The hardcover tag uses the Hardcover metadata service
+# (softcover = Goodreads). Runs non-root as uid 1001.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/pennydreadful/bookshelf
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ''
+
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+# Ports to be exposed, grouped by services
+services:
+  - name: http
+    type: ClusterIP
+    port: 8787
+    protocol: TCP
+    ingress:
+      className: nginx-internal
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      hosts:
+        - host: bookshelf.drewburr.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+        - secretName: bookshelf-ingress
+          hosts:
+            - bookshelf.drewburr.com
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Appended to env. Supports envFrom
+env: []
+
+# Key: value environment variables to be appended to env
+envVars:
+  TZ: America/New_York
+
+# Mounts the full plex-data volume at /data so download client paths
+# (qbittorrent/sabnzbd category dirs) resolve without remote path mappings.
+persistence:
+  - name: bookshelf-config
+    mountPath: config
+    accessModes:
+      - ReadWriteOnce
+    requests: 10Gi
+    storageClassName: zfs-nvmeof
+  - name: plex-data
+    mountPath: data
+
+nodeSelector: {}
+
+tolerations:
+  - key: compute
+    operator: Exists
+    effect: PreferNoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: compute
+              operator: In
+              values:
+                - 'true'
+
+startupProbe:
+  httpGet:
+    path: /
+    port: 8787
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet:
+    path: /
+    port: 8787
+readinessProbe:
+  httpGet:
+    path: /
+    port: 8787

--- a/k8s/plex/calibre-web/.helmignore
+++ b/k8s/plex/calibre-web/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/calibre-web/Chart.yaml
+++ b/k8s/plex/calibre-web/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: calibre-web
+description: A Helm chart for deploying Calibre-Web NextGen (CWA continuation)
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/calibre-web/README.md
+++ b/k8s/plex/calibre-web/README.md
@@ -28,15 +28,10 @@ privilege-drop loop), which is why NextGen is used.
                               bookshelf root folder: /data/books/ingest)
 ```
 
-fsGroup does not chown NFS volumes, so the subtree must be pre-created on
-storage01 before first sync:
-
-```sh
-ssh ubuntu@storage01.drewburr.com
-D=/lake/k8s/nvmeof/dataset/pvc-1a6ee17d-54a9-47e3-808f-b266d21d1fd9
-sudo mkdir -p $D/books/calibre-library $D/books/ingest
-sudo chown -R 1001:1001 $D/books
-```
+The subtree is created by `mkdir` initContainers (same pattern as the plex
+chart's mkdir init), running as 1001 since fsGroup does not chown NFS
+volumes. calibre-web creates both dirs; shelfmark creates the ingest dir so
+neither app depends on the other's sync order.
 
 ## Post-deploy wiring (one-time, in-app)
 

--- a/k8s/plex/calibre-web/README.md
+++ b/k8s/plex/calibre-web/README.md
@@ -1,0 +1,53 @@
+# Books stack (calibre-web / shelfmark / bookshelf)
+
+Self-serve ebook pipeline living in the plex namespace so it can reuse the
+existing qbittorrent, sabnzbd, flare-bypasser, and plex-data infrastructure.
+
+- **calibre-web** — Calibre-Web NextGen (community continuation of
+  Calibre-Web-Automated). Family-facing library UI at
+  <https://books.drewburr.com> (external ingress). Per-user accounts,
+  send-to-kindle email, OPDS, auto-convert, auto-ingest.
+- **shelfmark** — search/download UI at <https://shelfmark.drewburr.com>
+  (internal only — it has **no built-in auth**; front with Authentik before
+  exposing externally). Drops books into the shared ingest folder. Uses the
+  existing flare-bypasser instead of its bundled SeleniumBase one.
+- **bookshelf** — Readarr fork at <https://bookshelf.drewburr.com> (internal).
+  Monitored-author automation via the existing download clients. `hardcover`
+  image tag = Hardcover metadata; `softcover` = Goodreads.
+
+All three run rootless (uid/gid 1001, `runAsNonRoot`), verified with
+`podman run --user 1001:1001` on 2026-08-21. The original
+crocodilestick/calibre-web-automated image cannot start non-root (s6
+privilege-drop loop), which is why NextGen is used.
+
+## Shared paths on plex-data
+
+```text
+/data/books/calibre-library   calibre library (calibre-web: /calibre-library)
+/data/books/ingest            ingest drop (calibre-web + shelfmark: /cwa-book-ingest,
+                              bookshelf root folder: /data/books/ingest)
+```
+
+fsGroup does not chown NFS volumes, so the subtree must be pre-created on
+storage01 before first sync:
+
+```sh
+ssh ubuntu@storage01.drewburr.com
+D=/lake/k8s/nvmeof/dataset/pvc-1a6ee17d-54a9-47e3-808f-b266d21d1fd9
+sudo mkdir -p $D/books/calibre-library $D/books/ingest
+sudo chown -R 1001:1001 $D/books
+```
+
+## Post-deploy wiring (one-time, in-app)
+
+1. **calibre-web**: create the library at `/calibre-library`; set ingest dir
+   `/cwa-book-ingest`; configure SMTP for send-to-kindle; create family user
+   accounts (each user sets their own `@kindle.com` address and whitelists
+   the sender address in their Amazon account).
+2. **bookshelf**: add download clients `plex-qbittorrent-http:8080`
+   (category `books`) and `plex-sabnzbd-http:8080` (category `books`); add
+   indexers (Jackett Torznab feeds); set root folder `/data/books/ingest` so
+   completed imports flow through calibre-web ingest. Note qbittorrent-alt
+   also exists if the primary's VPN egress isn't wanted for books.
+3. **qbittorrent/sabnzbd**: create the `books` categories with save paths
+   under `/data/` so bookshelf can import without path mapping.

--- a/k8s/plex/calibre-web/templates/_helpers.tpl
+++ b/k8s/plex/calibre-web/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "calibre-web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "calibre-web.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "calibre-web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "calibre-web.labels" -}}
+helm.sh/chart: {{ include "calibre-web.chart" . }}
+{{ include "calibre-web.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "calibre-web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "calibre-web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "calibre-web.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "calibre-web.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/calibre-web/templates/deployment.yaml
+++ b/k8s/plex/calibre-web/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "calibre-web.deployment") -}}
+{{- define "calibre-web.deployment" -}}
+{{- end -}}

--- a/k8s/plex/calibre-web/templates/ingress.yaml
+++ b/k8s/plex/calibre-web/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/calibre-web/templates/pvc.yaml
+++ b/k8s/plex/calibre-web/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/calibre-web/templates/service.yaml
+++ b/k8s/plex/calibre-web/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/calibre-web/templates/serviceaccount.yaml
+++ b/k8s/plex/calibre-web/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "calibre-web.serviceaccount") -}}
+{{- end -}}
+{{- define "calibre-web.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/calibre-web/values.yaml
+++ b/k8s/plex/calibre-web/values.yaml
@@ -1,0 +1,131 @@
+# https://github.com/new-usemame/Calibre-Web-NextGen
+# Community continuation of Calibre-Web-Automated. Chosen over
+# crocodilestick/calibre-web-automated because the original's s6 init cannot
+# start non-root (s6-applyuidgid loops); NextGen runs cleanly as uid 1001.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/new-usemame/calibre-web-nextgen
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ''
+
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+# Ports to be exposed, grouped by services
+services:
+  - name: http
+    type: ClusterIP
+    port: 8083
+    protocol: TCP
+    ingress:
+      className: nginx-external
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+        external-dns.alpha.kubernetes.io/target: ip.drewburr.com
+      hosts:
+        - host: books.drewburr.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+        - secretName: calibre-web-ingress
+          hosts:
+            - books.drewburr.com
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Appended to env. Supports envFrom
+env: []
+
+# Key: value environment variables to be appended to env
+envVars:
+  TZ: America/New_York
+  # Library and ingest live on plex-data (NFS); enables sqlite-safe locking
+  # and polling file-watch instead of inotify.
+  NETWORK_SHARE_MODE: true
+
+persistence:
+  - name: calibre-web-config
+    mountPath: config
+    accessModes:
+      - ReadWriteOnce
+    requests: 10Gi
+    storageClassName: zfs-nvmeof
+
+# Library chart persistence has no subPath support, so plex-data subdirs are
+# mounted via additionalVolumes/Mounts. The books/ subtree must exist on the
+# share and be owned 1001 (fsGroup does not chown NFS volumes).
+additionalVolumes:
+  - name: plex-data
+    persistentVolumeClaim:
+      claimName: plex-data
+
+additionalVolumeMounts:
+  - name: plex-data
+    mountPath: /calibre-library
+    subPath: books/calibre-library
+  - name: plex-data
+    mountPath: /cwa-book-ingest
+    subPath: books/ingest
+
+nodeSelector: {}
+
+tolerations:
+  - key: compute
+    operator: Exists
+    effect: PreferNoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: compute
+              operator: In
+              values:
+                - 'true'
+
+startupProbe:
+  httpGet:
+    path: /
+    port: 8083
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet:
+    path: /
+    port: 8083
+readinessProbe:
+  httpGet:
+    path: /
+    port: 8083

--- a/k8s/plex/calibre-web/values.yaml
+++ b/k8s/plex/calibre-web/values.yaml
@@ -115,6 +115,29 @@ affinity:
               values:
                 - 'true'
 
+# Creates the books subtree on plex-data before the subPath mounts resolve.
+# Runs as 1001 like the plex mkdir init; fsGroup can't chown NFS so the dirs
+# must be created by the owning uid.
+initContainers:
+  - name: mkdir
+    image:
+      repository: alpine
+      pullPolicy: Always
+      tag: latest
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+    command:
+      - sh
+      - -c
+      - >-
+        mkdir -p /data/books/calibre-library &&
+        mkdir -p /data/books/ingest
+    volumeMountsOverride:
+      - name: plex-data
+        mountPath: /data
+
 startupProbe:
   httpGet:
     path: /

--- a/k8s/plex/shelfmark/.helmignore
+++ b/k8s/plex/shelfmark/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/shelfmark/Chart.yaml
+++ b/k8s/plex/shelfmark/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: shelfmark
+description: A Helm chart for deploying Shelfmark (book search/download UI)
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/shelfmark/templates/_helpers.tpl
+++ b/k8s/plex/shelfmark/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "shelfmark.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "shelfmark.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "shelfmark.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "shelfmark.labels" -}}
+helm.sh/chart: {{ include "shelfmark.chart" . }}
+{{ include "shelfmark.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "shelfmark.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "shelfmark.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "shelfmark.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "shelfmark.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/shelfmark/templates/deployment.yaml
+++ b/k8s/plex/shelfmark/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "shelfmark.deployment") -}}
+{{- define "shelfmark.deployment" -}}
+{{- end -}}

--- a/k8s/plex/shelfmark/templates/ingress.yaml
+++ b/k8s/plex/shelfmark/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/shelfmark/templates/pvc.yaml
+++ b/k8s/plex/shelfmark/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/shelfmark/templates/service.yaml
+++ b/k8s/plex/shelfmark/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/shelfmark/templates/serviceaccount.yaml
+++ b/k8s/plex/shelfmark/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "shelfmark.serviceaccount") -}}
+{{- end -}}
+{{- define "shelfmark.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -1,0 +1,134 @@
+# https://github.com/calibrain/shelfmark
+# Formerly calibre-web-automated-book-downloader. Search/download UI that
+# drops books into the CWA ingest folder. Runs non-root; entrypoint requires
+# writable /tmp/shelfmark, /var/log/shelfmark, and /config in that mode.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/calibrain/shelfmark
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ''
+
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+# Ports to be exposed, grouped by services
+services:
+  - name: http
+    type: ClusterIP
+    port: 8084
+    protocol: TCP
+    ingress:
+      className: nginx-internal
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      hosts:
+        - host: shelfmark.drewburr.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+        - secretName: shelfmark-ingress
+          hosts:
+            - shelfmark.drewburr.com
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Appended to env. Supports envFrom
+env: []
+
+# Key: value environment variables to be appended to env
+envVars:
+  TZ: America/New_York
+  INGEST_DIR: /cwa-book-ingest
+  # Built-in SeleniumBase bypasser needs image-layer writes that fail
+  # non-root; reuse the existing flare-bypasser deployment instead.
+  USING_EXTERNAL_BYPASSER: true
+  EXT_BYPASSER_URL: http://plex-flaresolverr-flare-bypasser-http:8080
+
+persistence:
+  - name: shelfmark-config
+    mountPath: config
+    accessModes:
+      - ReadWriteOnce
+    requests: 10Gi
+    storageClassName: zfs-nvmeof
+
+additionalVolumes:
+  - name: plex-data
+    persistentVolumeClaim:
+      claimName: plex-data
+  - name: tmp-shelfmark
+    emptyDir: {}
+  - name: log-shelfmark
+    emptyDir: {}
+
+additionalVolumeMounts:
+  - name: plex-data
+    mountPath: /cwa-book-ingest
+    subPath: books/ingest
+  - name: tmp-shelfmark
+    mountPath: /tmp/shelfmark
+  - name: log-shelfmark
+    mountPath: /var/log/shelfmark
+
+nodeSelector: {}
+
+tolerations:
+  - key: compute
+    operator: Exists
+    effect: PreferNoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: compute
+              operator: In
+              values:
+                - 'true'
+
+startupProbe:
+  httpGet:
+    path: /
+    port: 8084
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet:
+    path: /
+    port: 8084
+readinessProbe:
+  httpGet:
+    path: /
+    port: 8084

--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -118,6 +118,26 @@ affinity:
               values:
                 - 'true'
 
+# Same mkdir pattern as plex/calibre-web so shelfmark doesn't depend on
+# calibre-web having synced first.
+initContainers:
+  - name: mkdir
+    image:
+      repository: alpine
+      pullPolicy: Always
+      tag: latest
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1001
+      runAsGroup: 1001
+    command:
+      - sh
+      - -c
+      - mkdir -p /data/books/ingest
+    volumeMountsOverride:
+      - name: plex-data
+        mountPath: /data
+
 startupProbe:
   httpGet:
     path: /


### PR DESCRIPTION
Self-serve ebook pipeline in the plex namespace, per discussion:

- **calibre-web** (Calibre-Web NextGen) — family-facing library + send-to-kindle at books.drewburr.com (external)
- **shelfmark** — search/download UI feeding the ingest folder (internal only: no built-in auth)
- **bookshelf** — Readarr fork for monitored authors, wired to the existing qbittorrent/sabnzbd (internal)

All rootless (runAsNonRoot 1001), tested with podman. Shelfmark uses the existing flare-bypasser via `USING_EXTERNAL_BYPASSER` instead of its bundled Selenium stack.

The `/data/books/{calibre-library,ingest}` subtree is created by `mkdir` initContainers running as 1001, matching the plex chart's pattern — no manual storage prep needed. Post-deploy in-app wiring steps are in `k8s/plex/calibre-web/README.md`.