### PR TITLE
Bookshelf: bookshelfng fork for qBittorrent 5.2 auth fix

### DIFF
--- a/k8s/plex/bookshelf/values.yaml
+++ b/k8s/plex/bookshelf/values.yaml
@@ -1,14 +1,18 @@
-# https://github.com/pennydreadful/bookshelf
+# https://github.com/EasyAsABC123/bookshelfng
 # Readarr fork for monitored-author grabs via the existing qbittorrent and
-# sabnzbd deployments. The hardcover tag uses the Hardcover metadata service
-# (softcover = Goodreads). Runs non-root as uid 1001.
+# sabnzbd deployments. bookshelfng over pennydreadful/bookshelf: qBittorrent
+# 5.2+ returns HTTP 204 on login, which pennydreadful mislabels as an auth
+# failure (pennydreadful/bookshelf#160, stale since Feb 2026); bookshelfng
+# carries the fix. Tag pinned to an immutable build (trivy-scanned 2026-08-22:
+# 0 critical / 3 inherited .NET-runtime highs). hardcover-* tags use the
+# Hardcover metadata service (softcover = Goodreads). Runs non-root as 1001.
 replicaCount: 1
 
 image:
-  repository: ghcr.io/pennydreadful/bookshelf
+  repository: ghcr.io/easyasabc123/bookshelfng
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ''
+  tag: 'hardcover-develop-50cd486'
 
 imagePullSecrets: []
 nameOverride: ''


### PR DESCRIPTION
Root cause of the download-client auth failures: qBittorrent 5.2 changed `/api/v2/auth/login` to return **204 No Content** on success; pennydreadful/bookshelf requires 200 + `Ok.` and reports it as an authentication failure ([pennydreadful/bookshelf#160](https://github.com/pennydreadful/bookshelf/issues/160)). Credentials and connectivity were verified fine — qbittorrent logged successful logins from the bookshelf pod while the test still failed. (Same 5.2 change explains the 204 quirk on the qbit login page.)

pennydreadful is stale (last commit Feb 2026); [EasyAsABC123/bookshelfng](https://github.com/EasyAsABC123/bookshelfng) carries the fix. Pinned immutable tag `hardcover-develop-50cd486`:
- trivy: 0 CRITICAL / 3 HIGH (inherited .NET 6 runtime libs; old image scores 22)
- no OS-package vulns, no secrets
- verified runs rootless as 1001 (podman)

The existing `bookshelf-config` PVC carries over — download client config entered so far is preserved.