### PR TITLE
Shelfmark: family logins via calibre-web accounts, external ingress

### DIFF
--- a/k8s/plex/calibre-web/README.md
+++ b/k8s/plex/calibre-web/README.md
@@ -8,9 +8,12 @@ existing qbittorrent, sabnzbd, flare-bypasser, and plex-data infrastructure.
   <https://books.drewburr.com> (external ingress). Per-user accounts,
   send-to-kindle email, OPDS, auto-convert, auto-ingest.
 - **shelfmark** — search/download UI at <https://shelfmark.drewburr.com>
-  (internal only — it has **no built-in auth**; front with Authentik before
-  exposing externally). Drops books into the shared ingest folder. Uses the
-  existing flare-bypasser instead of its bundled SeleniumBase one.
+  (external; `AUTH_METHOD=cwa` reuses calibre-web's user database, so family
+  members log in with their books.drewburr.com account). Drops books into
+  the shared ingest folder. Uses the existing flare-bypasser instead of its
+  bundled SeleniumBase one. Pinned to calibre-web's node via required
+  podAffinity — it mounts the RWO calibre-web-config PVC read-only for
+  app.db.
 - **bookshelf** — Readarr fork at <https://bookshelf.drewburr.com> (internal).
   Monitored-author automation via the existing download clients. `hardcover`
   image tag = Hardcover metadata; `softcover` = Goodreads.

--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -41,9 +41,10 @@ services:
     port: 8084
     protocol: TCP
     ingress:
-      className: nginx-internal
+      className: nginx-external
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
+        external-dns.alpha.kubernetes.io/target: ip.drewburr.com
       hosts:
         - host: shelfmark.drewburr.com
           paths:
@@ -73,6 +74,12 @@ envVars:
   # non-root; reuse the existing flare-bypasser deployment instead.
   USING_EXTERNAL_BYPASSER: true
   EXT_BYPASSER_URL: http://plex-flaresolverr-flare-bypasser-http:8080
+  # Family logins reuse calibre-web's user database (same accounts as
+  # books.drewburr.com). The whole config dir is mounted (not just app.db)
+  # so sqlite WAL/shm sidecar files stay visible to the reader.
+  AUTH_METHOD: cwa
+  CWA_DB_PATH: /auth-cw/app.db
+  SESSION_COOKIE_SECURE: true
 
 persistence:
   - name: shelfmark-config
@@ -90,6 +97,10 @@ additionalVolumes:
     emptyDir: {}
   - name: log-shelfmark
     emptyDir: {}
+  - name: calibre-web-config
+    persistentVolumeClaim:
+      claimName: calibre-web-config
+      readOnly: true
 
 additionalVolumeMounts:
   - name: plex-data
@@ -99,6 +110,9 @@ additionalVolumeMounts:
     mountPath: /tmp/shelfmark
   - name: log-shelfmark
     mountPath: /var/log/shelfmark
+  - name: calibre-web-config
+    mountPath: /auth-cw
+    readOnly: true
 
 nodeSelector: {}
 
@@ -107,7 +121,15 @@ tolerations:
     operator: Exists
     effect: PreferNoSchedule
 
+# Hard co-scheduling with calibre-web: calibre-web-config is RWO block
+# storage (zfs-nvmeof), only mountable by pods on the same node.
 affinity:
+  podAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/instance: plex-calibre-web
+        topologyKey: kubernetes.io/hostname
   nodeAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:
       - weight: 100


### PR DESCRIPTION
Makes the request flow work off-network: family members hit **shelfmark.drewburr.com**, log in with the **same account they use on books.drewburr.com**, and request books.

- `AUTH_METHOD=cwa` + `CWA_DB_PATH=/auth-cw/app.db` — shelfmark authenticates against calibre-web's user database (supported natively; verified in shelfmark source/docs)
- Mounts the `calibre-web-config` PVC read-only at `/auth-cw` (whole dir so sqlite `-wal`/`-shm` files stay visible)
- **Required podAffinity** to `plex-calibre-web` — the PVC is RWO block storage, so both pods must share a node; no node labels needed, the scheduler resolves it via pod labels
- Ingress → `nginx-external` (+ external-dns target, `SESSION_COOKIE_SECURE=true`)

After sync, verify: shelfmark pod lands on calibre-web's node and Ready; log in from off-network with a calibre-web account; request → book appears in books.drewburr.com. If the read-only sqlite open misbehaves with WAL mode, fallback is dropping `readOnly` on the mount.