### PR TITLE
Shelfmark at books.drewburr.com/request

### DIFF
--- a/k8s/plex/calibre-web/README.md
+++ b/k8s/plex/calibre-web/README.md
@@ -7,13 +7,16 @@ existing qbittorrent, sabnzbd, flare-bypasser, and plex-data infrastructure.
   Calibre-Web-Automated). Family-facing library UI at
   <https://books.drewburr.com> (external ingress). Per-user accounts,
   send-to-kindle email, OPDS, auto-convert, auto-ingest.
-- **shelfmark** — search/download UI at <https://shelfmark.drewburr.com>
-  (external; `AUTH_METHOD=cwa` reuses calibre-web's user database, so family
-  members log in with their books.drewburr.com account). Drops books into
-  the shared ingest folder. Uses the existing flare-bypasser instead of its
-  bundled SeleniumBase one. Pinned to calibre-web's node via required
-  podAffinity — it mounts the RWO calibre-web-config PVC read-only for
-  app.db.
+- **shelfmark** — search/request UI at <https://books.drewburr.com/request>
+  (subpath on the books host via `URL_BASE`; `AUTH_METHOD=cwa` reuses
+  calibre-web's user database, so family members log in with their
+  books.drewburr.com account, and `CALIBRE_WEB_URL` gives it a "Library"
+  button back to the main site). Drops books into the shared ingest folder.
+  Uses the existing flare-bypasser instead of its bundled SeleniumBase one.
+  Pinned to calibre-web's node via required podAffinity — it mounts the RWO
+  calibre-web-config PVC read-only for app.db. Its ingress carries no tls
+  block or DNS annotation: the calibre-web ingress owns cert and DNS for
+  the host.
 - **bookshelf** — Readarr fork at <https://bookshelf.drewburr.com> (internal).
   Monitored-author automation via the existing download clients. `hardcover`
   image tag = Hardcover metadata; `softcover` = Goodreads.

--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -40,20 +40,18 @@ services:
     type: ClusterIP
     port: 8084
     protocol: TCP
+    # Served under books.drewburr.com/request (URL_BASE below). No tls block:
+    # the calibre-web ingress already terminates TLS for this host and a
+    # second cert-manager claim on the same host would fight it. DNS is
+    # likewise owned by the calibre-web ingress record.
     ingress:
       className: nginx-external
-      annotations:
-        cert-manager.io/cluster-issuer: letsencrypt
-        external-dns.alpha.kubernetes.io/target: ip.drewburr.com
+      annotations: {}
       hosts:
-        - host: shelfmark.drewburr.com
+        - host: books.drewburr.com
           paths:
-            - path: /
+            - path: /request
               pathType: ImplementationSpecific
-      tls:
-        - secretName: shelfmark-ingress
-          hosts:
-            - shelfmark.drewburr.com
 
 resources: {}
   # limits:
@@ -80,6 +78,11 @@ envVars:
   AUTH_METHOD: cwa
   CWA_DB_PATH: /auth-cw/app.db
   SESSION_COOKIE_SECURE: true
+  # Subpath hosting under the books host (natively supported; UI, API,
+  # assets, and Socket.IO all serve under this base).
+  URL_BASE: /request/
+  # Adds a "Library" button in shelfmark's header linking back to the library.
+  CALIBRE_WEB_URL: https://books.drewburr.com
 
 persistence:
   - name: shelfmark-config


### PR DESCRIPTION
Family-facing URL consolidation: shelfmark moves from shelfmark.drewburr.com to **books.drewburr.com/request**.

- `URL_BASE=/request/` — shelfmark supports subpath hosting natively (no nginx rewrites); UI, API, assets, and websockets all serve under the base
- Ingress claims path `/request` on the books host, **without** a tls block or external-dns/cert-manager annotations — the calibre-web ingress already owns the cert and DNS record for that host, and a second claim would conflict
- `CALIBRE_WEB_URL` enables shelfmark's built-in "Library" header button linking back to books.drewburr.com
- shelfmark.drewburr.com goes away; external-dns (policy: sync) prunes its records automatically

After sync: books.drewburr.com/request should serve shelfmark's login (same accounts as before); check the Library button and that a search works (websockets under the subpath). Note there's no calibre-web→shelfmark link in NextGen's UI — worth a bookmark/tip to family that /request is the request page.