### PR TITLE
Books: 'Request a Book' sidebar link via ingress sub_filter

### DIFF
--- a/k8s/plex/calibre-web/values.yaml
+++ b/k8s/plex/calibre-web/values.yaml
@@ -45,6 +45,19 @@ services:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         external-dns.alpha.kubernetes.io/target: ip.drewburr.com
+        # Injects a "Request a Book" sidebar entry linking to shelfmark at
+        # /request — NextGen has no native outbound-link setting yet
+        # (new-usemame/Calibre-Web-NextGen#1785). The anchor is the sidebar
+        # <ul> opening tag from cps/templates/layout.html; if an image
+        # update changes that tag the filter stops matching and the link
+        # silently disappears (nothing breaks — re-check the template and
+        # update the anchor). Accept-Encoding is stripped because sub_filter
+        # can't rewrite gzipped upstream responses; sub_filter only touches
+        # text/html by default.
+        nginx.ingress.kubernetes.io/configuration-snippet: |
+          proxy_set_header Accept-Encoding "";
+          sub_filter '<ul class="list-unstyled" id="scnd-nav" intent in-standard-append="nav.navigation" in-mobile-after="#main-nav" in-mobile-class="nav navbar-nav">' '<ul class="list-unstyled" id="scnd-nav" intent in-standard-append="nav.navigation" in-mobile-after="#main-nav" in-mobile-class="nav navbar-nav"><li><a href="/request/"><span class="glyphicon glyphicon-search"></span> Request a Book</a></li>';
+          sub_filter_once on;
       hosts:
         - host: books.drewburr.com
           paths:


### PR DESCRIPTION
Adds a **Request a Book** entry at the top of the books.drewburr.com sidebar, linking to shelfmark at `/request/`.

NextGen has no native setting for an outbound nav link — [new-usemame/Calibre-Web-NextGen#1785](https://github.com/new-usemame/Calibre-Web-NextGen/issues/1785) (open, enhancement) tracks exactly this. Until it lands, this uses an nginx `configuration-snippet` with `sub_filter` on the calibre-web ingress (snippet annotations are enabled on the external controller).

Known tradeoffs, called out in the values comment:
- Anchored to the sidebar `<ul id="scnd-nav">` tag from `cps/templates/layout.html` — if a NextGen update changes that tag, the link **silently disappears** (nothing else breaks); fix is re-checking the template and updating the anchor
- `Accept-Encoding` is stripped toward the upstream (sub_filter can't rewrite gzipped bodies) — calibre-web responses go uncompressed between pod and nginx; sub_filter itself only touches text/html
- Once #1785 ships a real setting, delete the snippet and use that instead

Verify after sync: sidebar shows "Request a Book" above Books when logged in, and clicking it lands on shelfmark.