### PR TITLE
Shelfmark: fix probes for URL_BASE subpath

### DIFF
--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -163,17 +163,19 @@ initContainers:
       - name: plex-data
         mountPath: /data
 
+# Probe paths must live under URL_BASE — with /request/ set, nothing is
+# served at / and the startup probe kills the pod after 5 minutes.
 startupProbe:
   httpGet:
-    path: /
+    path: /request/
     port: 8084
   failureThreshold: 30
   periodSeconds: 10
 livenessProbe:
   httpGet:
-    path: /
+    path: /request/
     port: 8084
 readinessProbe:
   httpGet:
-    path: /
+    path: /request/
     port: 8084


### PR DESCRIPTION
**My bug from #21**: moving shelfmark under `URL_BASE=/request/` left the probes pointing at `/`, which no longer serves anything — so the startup probe failed for its full 5-minute window and kubelet restarted the pod on a loop (the app itself was healthy; exit was a clean SIGTERM at exactly 300s). Impact: shelfmark never went Ready after the #21 sync.

Probes now hit `/request/`. Verified in the running pod: `/` errors, `/request/` returns 200.