### PR TITLE
Shelfmark: raise ingress proxy timeouts for slow release lookups

### DIFF
--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -46,7 +46,13 @@ services:
     # likewise owned by the calibre-web ingress record.
     ingress:
       className: nginx-external
-      annotations: {}
+      # Release lookups run through the Cloudflare bypasser and can take up
+      # to EXT_BYPASSER_TIMEOUT (180s, set in shelfmark's settings UI);
+      # nginx's default 60s proxy-read timeout returned the HTML error page
+      # mid-lookup, which the UI failed to parse as JSON.
+      annotations:
+        nginx.ingress.kubernetes.io/proxy-read-timeout: "200"
+        nginx.ingress.kubernetes.io/proxy-send-timeout: "200"
       hosts:
         - host: books.drewburr.com
           paths:


### PR DESCRIPTION
With the Cloudflare-bypass timeout raised to 180s (settings UI), release lookups legitimately outlive nginx's default 60s `proxy_read_timeout` — the ingress returned the custom HTML error page mid-request and shelfmark's UI showed *Unexpected token '<' … is not valid JSON*.

Sets `proxy-read-timeout`/`proxy-send-timeout` to 200s (bypasser budget + headroom) on the shelfmark ingress only; calibre-web and everything else keep defaults.