### PR TITLE
Shelfmark: mount /data/downloads for completed-download pickup

### DIFF
--- a/k8s/plex/shelfmark/values.yaml
+++ b/k8s/plex/shelfmark/values.yaml
@@ -115,6 +115,11 @@ additionalVolumeMounts:
   - name: plex-data
     mountPath: /cwa-book-ingest
     subPath: books/ingest
+  # sabnzbd/qbittorrent report completed paths under /data/downloads;
+  # shelfmark must see the same paths to collect finished downloads.
+  - name: plex-data
+    mountPath: /data/downloads
+    subPath: downloads
   - name: tmp-shelfmark
     mountPath: /tmp/shelfmark
   - name: log-shelfmark


### PR DESCRIPTION
Found during the end-to-end test: shelfmark handed an NZB to SABnzbd fine, sab completed it to `/data/downloads/usenet/complete/books/`, and the handoff stalled — shelfmark's pod only mounted the ingest subdir, so the path sab reports doesn't exist in its container and it can't collect the finished file.

Adds a `plex-data` subPath mount at `/data/downloads` (matches what sab/qbittorrent report). My omission from the original chart — the direct-download mode never needed it, the client-based mode does.

After sync the pod restarts; the already-completed *Project Hail Mary* download may need a re-trigger from shelfmark's Activity panel (or just grab it again) since the move likely errored while the path was missing.