### PR TITLE
Calibre-web: explicit WATCH_FOLDER for ingest service

### DIFF
--- a/k8s/plex/calibre-web/values.yaml
+++ b/k8s/plex/calibre-web/values.yaml
@@ -94,6 +94,11 @@ envVars:
   # Library and ingest live on plex-data (NFS); enables sqlite-safe locking
   # and polling file-watch instead of inotify.
   NETWORK_SHARE_MODE: true
+  # The cwa-ingest-service run script falls back to grepping dirs.json for
+  # the ingest folder and expects a space after the colon; the image's
+  # compact dirs.json doesn't match, leaving the watcher on an empty path
+  # (books sat in ingest forever). Setting the env skips that fragile parse.
+  WATCH_FOLDER: /cwa-book-ingest
 
 persistence:
   - name: calibre-web-config


### PR DESCRIPTION
Found in the end-to-end test: books landed in `/cwa-book-ingest` and sat there forever. The `cwa-ingest-service` run script's fallback parse is `grep -o '"ingest_folder": "...'` — it requires a space after the colon, and the image's `dirs.json` is compact JSON without one, so `WATCH_FOLDER` resolved empty and the polling watcher watched nothing (visible at every boot as `Watching folder: ` with a blank value).

The script prefers a `WATCH_FOLDER` env when set, so this pins it to `/cwa-book-ingest` and skips the fragile parse entirely. Couldn't hot-fix in the pod — `/app` is read-only to uid 1001 (rootless hardening doing its job).

Upstream-worthy bug for NextGen (grep-parsing JSON); worth filing with them.

After sync the pod restarts; the two Project Hail Mary files already sitting in ingest should import within a couple of minutes of startup.