### PR TITLE
Books: kindle approved-sender onboarding steps

### DIFF
--- a/k8s/plex/calibre-web/README.md
+++ b/k8s/plex/calibre-web/README.md
@@ -76,7 +76,16 @@ Hard-won quirks, in the order they bit:
   email addresses** (being listed in the Apple ID "Email & Phone Numbers"
   sign-in list is a different registry and not sufficient).
 
-Per family member (the "email never arrives" checklist): calibre-web user
-profile has their `@kindle.com` address, and `books@drewburr.com` is in
-their Amazon **Approved Personal Document E-mail List** (amazon.com →
-Content & Devices → Preferences) — Amazon silently drops mail otherwise.
+### Per-family-member kindle onboarding
+
+The "email never arrives" checklist — both steps are required per person;
+Amazon silently drops mail otherwise:
+
+1. Their calibre-web user profile has their `@kindle.com` address (shown in
+   the Kindle app / device settings, or on the Amazon page below under
+   "Personal Document Settings").
+2. In **their** Amazon account, add `books@drewburr.com` as an approved
+   sender: <https://www.amazon.com/hz/mycd/preferences/myx#/home/settings/>
+   → scroll to the bottom (**Personal Document Settings → Approved Personal
+   Document E-mail List**) → "Add a new approved e-mail address" →
+   `books@drewburr.com`.

--- a/k8s/plex/calibre-web/README.md
+++ b/k8s/plex/calibre-web/README.md
@@ -89,3 +89,11 @@ Amazon silently drops mail otherwise:
    → scroll to the bottom (**Personal Document Settings → Approved Personal
    Document E-mail List**) → "Add a new approved e-mail address" →
    `books@drewburr.com`.
+
+After sending: a "Finished" task in calibre-web means the mail was handed
+off — delivery is then Amazon's side and takes several minutes. The book
+does NOT appear on its own until the device syncs: Kindle → Settings →
+**Sync**, then look under **Library → Docs** (sent books file as personal
+documents, not store purchases). Verified working 2026-08-22. If it still
+isn't there after ~20 min and a sync, the approved-sender entry is the
+usual culprit (Amazon drops unapproved mail with no bounce).


### PR DESCRIPTION
Doc-only: records the exact Amazon URL and click-path each family member follows to whitelist `books@drewburr.com` (Personal Document Settings at the bottom of https://www.amazon.com/hz/mycd/preferences/myx#/home/settings/), plus where to find their @kindle.com address.