### PR TITLE
Calibre-web: liveness tolerance for send-to-ereader wedge

### DIFF
--- a/k8s/plex/calibre-web/values.yaml
+++ b/k8s/plex/calibre-web/values.yaml
@@ -171,11 +171,20 @@ startupProbe:
     port: 8083
   failureThreshold: 30
   periodSeconds: 10
+# NextGen's single gevent worker wedges (stops answering HTTP) while
+# in-process tasks run — send-to-ereader conversion+SMTP reliably wedged it
+# for ~1min and the default liveness (3x10s) killed the pod mid-send, every
+# send. Tolerate ~3min of wedge before restarting; readiness keeps pulling
+# the endpoint so the UI 503s briefly instead of the pod dying.
 livenessProbe:
   httpGet:
     path: /
     port: 8083
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 6
 readinessProbe:
   httpGet:
     path: /
     port: 8083
+  timeoutSeconds: 5


### PR DESCRIPTION
Every **Send to eReader** attempt was killing the pod: the task's conversion+SMTP work wedges NextGen's single gevent event loop (a failure family their changelog documents), HTTP stops answering, and the default liveness (3×10s) SIGTERMs the pod mid-send — observed twice as exit 137 with a clean `webserver stop` preceding it, no application traceback.

- Liveness now allows ~3 minutes of unresponsiveness (30s period × 6 failures, 5s timeout) — enough for the task to finish and the loop to recover
- Readiness stays tight-ish so the endpoint drops out of the service during a wedge (UI 503s briefly) rather than routing to a hung worker

Upstream this is NextGen's bug (in-process worker starving the loop); worth reporting alongside the dirs.json and duplicates-API issues found today.

Verify after sync: Send to eReader completes with the pod staying up (restart count stable), and the email actually arrives.