### PR TITLE
Prowlarr: indexer manager (torrent sources for shelfmark)

### DIFF
--- a/k8s/plex/prowlarr/.helmignore
+++ b/k8s/plex/prowlarr/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/prowlarr/Chart.yaml
+++ b/k8s/plex/prowlarr/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: prowlarr
+description: A Helm chart for deploying Prowlarr (indexer manager)
+type: application
+version: 0.1.0
+appVersion: "2.6.1"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/prowlarr/templates/_helpers.tpl
+++ b/k8s/plex/prowlarr/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prowlarr.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prowlarr.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prowlarr.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prowlarr.labels" -}}
+helm.sh/chart: {{ include "prowlarr.chart" . }}
+{{ include "prowlarr.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prowlarr.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prowlarr.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prowlarr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prowlarr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/prowlarr/templates/deployment.yaml
+++ b/k8s/plex/prowlarr/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "prowlarr.deployment") -}}
+{{- define "prowlarr.deployment" -}}
+{{- end -}}

--- a/k8s/plex/prowlarr/templates/ingress.yaml
+++ b/k8s/plex/prowlarr/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/prowlarr/templates/pvc.yaml
+++ b/k8s/plex/prowlarr/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/prowlarr/templates/service.yaml
+++ b/k8s/plex/prowlarr/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/prowlarr/templates/serviceaccount.yaml
+++ b/k8s/plex/prowlarr/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "prowlarr.serviceaccount") -}}
+{{- end -}}
+{{- define "prowlarr.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/prowlarr/values.yaml
+++ b/k8s/plex/prowlarr/values.yaml
@@ -1,0 +1,114 @@
+# https://github.com/home-operations/containers
+# Indexer manager: gives shelfmark torrent release sources (shelfmark speaks
+# Prowlarr, not Jackett) and can sync indexers to bookshelf/sonarr/radarr,
+# eventually retiring jackett. home-operations image chosen over
+# linuxserver/hotio: rootless by design (no s6 root init; default user is
+# nobody), verified as 1001 via podman and trivy-scanned (0 critical, 6
+# inherited .NET runtime highs) on 2026-08-22.
+replicaCount: 1
+
+image:
+  repository: ghcr.io/home-operations/prowlarr
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ''
+
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
+podAnnotations: {}
+
+podSecurityContext:
+  fsGroup: 1001
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+
+# Ports to be exposed, grouped by services
+services:
+  - name: http
+    type: ClusterIP
+    port: 9696
+    protocol: TCP
+    ingress:
+      className: nginx-internal
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt
+      hosts:
+        - host: prowlarr.drewburr.com
+          paths:
+            - path: /
+              pathType: ImplementationSpecific
+      tls:
+        - secretName: prowlarr-ingress
+          hosts:
+            - prowlarr.drewburr.com
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# Appended to env. Supports envFrom
+env: []
+
+# Key: value environment variables to be appended to env
+envVars:
+  TZ: America/New_York
+
+persistence:
+  - name: prowlarr-config
+    mountPath: config
+    accessModes:
+      - ReadWriteOnce
+    requests: 10Gi
+    storageClassName: zfs-nvmeof
+
+nodeSelector: {}
+
+tolerations:
+  - key: compute
+    operator: Exists
+    effect: PreferNoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: compute
+              operator: In
+              values:
+                - 'true'
+
+startupProbe:
+  httpGet:
+    path: /ping
+    port: 9696
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  httpGet:
+    path: /ping
+    port: 9696
+readinessProbe:
+  httpGet:
+    path: /ping
+    port: 9696


### PR DESCRIPTION
Adds Prowlarr to the plex namespace so shelfmark gets **torrent** release sources through your existing infra — its native integration searches Prowlarr and hands grabs to qbittorrent (category `books`, VPN'd egress), completing the story that started with "lean on the plex qbittorrent".

- `ghcr.io/home-operations/prowlarr:2.6.1` — rootless **by design** (default user `nobody`, no s6 root-init, unlike linuxserver/hotio); verified serving as uid 1001 via podman
- trivy: 0 CRITICAL / 6 HIGH, all inherited .NET runtime libs; no OS vulns, no secrets; internal ingress only (prowlarr.drewburr.com)
- Standard library-chart pattern; probes on `/ping` (Servarr health endpoint, no auth)
- Longer term Prowlarr can sync indexers to bookshelf (and sonarr/radarr) and retire jackett — not touched in this PR

Post-sync wiring is UI-side and I'll walk it: Prowlarr indexers (port from jackett), then shelfmark Settings → Prowlarr (URL + API key + qbittorrent client).