### PR TITLE
rreading-glasses: own metadata server for Bookshelf

### DIFF
--- a/k8s/plex/bookshelf/files/series_reconciler.py
+++ b/k8s/plex/bookshelf/files/series_reconciler.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Series reconciler for Bookshelf.
+
+Bookshelf (Readarr lineage) has no persisted series-level monitoring: the
+UI's series bookmark only bulk-toggles the books that exist at click time,
+so future volumes arrive per the author's monitor-new-items setting. With
+that set to "none" (to avoid the author firehose), new volumes of a wanted
+series would sit unmonitored forever.
+
+This reconciler closes the gap. Intent is declared by tagging an author in
+Bookshelf with the kebab-case slug of a series title (e.g. tag
+"dungeon-crawler-carl" on Matt Dinniman). Each run, for every tagged
+series, any volume that is unmonitored, has no file, and has never been
+grabbed or imported (history check — this is what distinguishes a NEW
+volume from one already handled and unmonitored after calibre-web consumed
+it) is monitored and searched.
+
+Env: BOOKSHELF_URL, BOOKSHELF_API_KEY, DRY_RUN (optional, any value).
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+
+BASE = os.environ["BOOKSHELF_URL"].rstrip("/")
+KEY = os.environ["BOOKSHELF_API_KEY"]
+DRY = bool(os.environ.get("DRY_RUN"))
+
+
+def api(path, method="GET", body=None):
+    req = urllib.request.Request(
+        f"{BASE}/api/v1/{path}",
+        method=method,
+        headers={"X-Api-Key": KEY, "Content-Type": "application/json"},
+        data=json.dumps(body).encode() if body is not None else None,
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        raw = r.read()
+    return json.loads(raw) if raw else None
+
+
+def slug(text):
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", text.lower())).strip("-")
+
+
+def series_name(book):
+    # seriesTitle looks like "The Empyrean #3"; bare titles pass through.
+    title = book.get("seriesTitle") or ""
+    return re.sub(r"\s*#[\d.\-]+$", "", title).strip()
+
+
+def was_handled(book_id):
+    hist = api(f"history?bookId={book_id}&pageSize=50")
+    events = hist.get("records", hist) if isinstance(hist, dict) else hist
+    return any(
+        e.get("eventType") in ("grabbed", "bookFileImported", "downloadImported")
+        for e in events or []
+    )
+
+
+def main():
+    tags = {t["id"]: t["label"] for t in api("tag")}
+    to_search = []
+
+    for author in api("author"):
+        wanted = {tags[t] for t in author.get("tags", []) if t in tags}
+        if not wanted:
+            continue
+
+        name = author["authorName"]
+        # The series bookmark UI needs the author monitored; monitored alone
+        # grabs nothing (monitorNewItems stays "none").
+        if not author.get("monitored"):
+            print(f"[{name}] setting author monitored=true (monitorNewItems=none)")
+            if not DRY:
+                author["monitored"] = True
+                author["monitorNewItems"] = "none"
+                api(f"author/{author['id']}", "PUT", author)
+
+        for book in api(f"book?authorId={author['id']}"):
+            sname = series_name(book)
+            if not sname or slug(sname) not in wanted:
+                continue
+            if book.get("monitored"):
+                continue
+            stats = book.get("statistics") or {}
+            if stats.get("bookFileCount", 0) > 0:
+                continue
+            if was_handled(book["id"]):
+                continue
+            print(f"[{name}] new volume in '{sname}': {book['title']}")
+            to_search.append(book["id"])
+
+    if to_search:
+        print(f"monitoring + searching {len(to_search)} book(s)")
+        if not DRY:
+            api("book/monitor", "PUT", {"bookIds": to_search, "monitored": True})
+            api("command", "POST", {"name": "BookSearch", "bookIds": to_search})
+    else:
+        print("nothing to do")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001 - surface any failure in job logs
+        print(f"reconciler failed: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/k8s/plex/bookshelf/templates/reconciler.yaml
+++ b/k8s/plex/bookshelf/templates/reconciler.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bookshelf-series-reconciler
+  labels:
+    {{- include "bookshelf.labels" . | nindent 4 }}
+data:
+  series_reconciler.py: |
+{{ .Files.Get "files/series_reconciler.py" | indent 4 }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bookshelf-series-reconciler
+  labels:
+    {{- include "bookshelf.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.reconciler.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            runAsGroup: 1001
+          containers:
+            - name: reconciler
+              image: {{ .Values.reconciler.image }}
+              command: ["python3", "/app/series_reconciler.py"]
+              env:
+                - name: BOOKSHELF_URL
+                  value: http://plex-bookshelf-http:8787
+                - name: BOOKSHELF_API_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: bookshelf-reconciler
+                      key: apiKey
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  memory: 128Mi
+              volumeMounts:
+                - name: script
+                  mountPath: /app
+          volumes:
+            - name: script
+              configMap:
+                name: bookshelf-series-reconciler

--- a/k8s/plex/bookshelf/values.yaml
+++ b/k8s/plex/bookshelf/values.yaml
@@ -103,6 +103,16 @@ affinity:
               values:
                 - 'true'
 
+# Series reconciler: hourly CronJob that gives Bookshelf the series-level
+# monitoring it lacks natively. Tag an author with the kebab-case series
+# slug (e.g. dungeon-crawler-carl) to declare intent; new volumes in tagged
+# series (unmonitored, fileless, never grabbed per history) get monitored
+# and searched. Requires Secret bookshelf-reconciler with key apiKey
+# (Bookshelf's API key) — created out-of-band like other secrets.
+reconciler:
+  schedule: "15 * * * *"
+  image: docker.io/library/python:3.12-alpine
+
 startupProbe:
   httpGet:
     path: /

--- a/k8s/plex/rreading-glasses-db/.helmignore
+++ b/k8s/plex/rreading-glasses-db/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/rreading-glasses-db/Chart.yaml
+++ b/k8s/plex/rreading-glasses-db/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: rreading-glasses-db
+description: PostgreSQL for Bazarr
+type: application
+version: 0.1.0
+appVersion: "18"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/rreading-glasses-db/templates/_helpers.tpl
+++ b/k8s/plex/rreading-glasses-db/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rreading-glasses-db.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "rreading-glasses-db.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rreading-glasses-db.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rreading-glasses-db.labels" -}}
+helm.sh/chart: {{ include "rreading-glasses-db.chart" . }}
+{{ include "rreading-glasses-db.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rreading-glasses-db.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rreading-glasses-db.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rreading-glasses-db.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rreading-glasses-db.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/rreading-glasses-db/templates/deployment.yaml
+++ b/k8s/plex/rreading-glasses-db/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "rreading-glasses-db.deployment") -}}
+{{- define "rreading-glasses-db.deployment" -}}
+{{- end -}}

--- a/k8s/plex/rreading-glasses-db/templates/pvc.yaml
+++ b/k8s/plex/rreading-glasses-db/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/rreading-glasses-db/templates/service.yaml
+++ b/k8s/plex/rreading-glasses-db/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/rreading-glasses-db/templates/serviceaccount.yaml
+++ b/k8s/plex/rreading-glasses-db/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "rreading-glasses-db.serviceaccount") -}}
+{{- end -}}
+{{- define "rreading-glasses-db.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/rreading-glasses-db/values.yaml
+++ b/k8s/plex/rreading-glasses-db/values.yaml
@@ -1,0 +1,89 @@
+replicaCount: 1
+
+image:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: "18-alpine"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "rreading-glasses-db"
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+# Run as postgres user (UID/GID 999) so PostgreSQL can own its data dir
+podSecurityContext:
+  fsGroup: 999
+  fsGroupChangePolicy: "OnRootMismatch"
+
+securityContext:
+  runAsUser: 999
+  runAsGroup: 999
+
+services:
+  - name: db
+    type: ClusterIP
+    port: 5432
+    protocol: TCP
+
+resources: {}
+
+env: []
+
+# Cluster-internal cache DB; in-values creds follow the bazarr-postgres
+# precedent. The data is a rebuildable metadata cache, not a system of
+# record.
+envVars:
+  POSTGRES_DB: rreading-glasses
+  POSTGRES_USER: rreading-glasses
+  POSTGRES_PASSWORD: rg-cache-n4Dp7qXe2w
+  # Subdirectory avoids issues with non-empty mount points
+  PGDATA: /var/lib/postgresql/data/pgdata
+
+# PVC name must not collide with bazarr's postgres-data claim (library
+# chart PVC names are not release-prefixed).
+persistence:
+  - name: rreading-glasses-db-data
+    mountPath: var/lib/postgresql/data
+    accessModes:
+      - ReadWriteOnce
+    requests: 5Gi
+    storageClassName: zfs-nvmeof
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+startupProbe:
+  exec:
+    command:
+      - pg_isready
+      - -U
+      - rreading-glasses
+      - -d
+      - rreading-glasses
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  exec:
+    command:
+      - pg_isready
+      - -U
+      - rreading-glasses
+      - -d
+      - rreading-glasses
+  timeoutSeconds: 5
+readinessProbe:
+  exec:
+    command:
+      - pg_isready
+      - -U
+      - rreading-glasses
+      - -d
+      - rreading-glasses
+  timeoutSeconds: 5

--- a/k8s/plex/rreading-glasses/.helmignore
+++ b/k8s/plex/rreading-glasses/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/plex/rreading-glasses/Chart.yaml
+++ b/k8s/plex/rreading-glasses/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: rreading-glasses
+description: A Helm chart for deploying rreading-glasses (Readarr metadata server)
+type: application
+version: 0.1.0
+appVersion: "hardcover"
+dependencies:
+- name: library
+  version: 0.0.0
+  repository: file://../library

--- a/k8s/plex/rreading-glasses/templates/_helpers.tpl
+++ b/k8s/plex/rreading-glasses/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rreading-glasses.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "rreading-glasses.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rreading-glasses.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "rreading-glasses.labels" -}}
+helm.sh/chart: {{ include "rreading-glasses.chart" . }}
+{{ include "rreading-glasses.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "rreading-glasses.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rreading-glasses.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "rreading-glasses.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rreading-glasses.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/k8s/plex/rreading-glasses/templates/deployment.yaml
+++ b/k8s/plex/rreading-glasses/templates/deployment.yaml
@@ -1,0 +1,3 @@
+{{- include "library.deployment" (list . "rreading-glasses.deployment") -}}
+{{- define "rreading-glasses.deployment" -}}
+{{- end -}}

--- a/k8s/plex/rreading-glasses/templates/ingress.yaml
+++ b/k8s/plex/rreading-glasses/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "library.ingresses" . -}}

--- a/k8s/plex/rreading-glasses/templates/pvc.yaml
+++ b/k8s/plex/rreading-glasses/templates/pvc.yaml
@@ -1,0 +1,1 @@
+{{- include "library.pvcs" . -}}

--- a/k8s/plex/rreading-glasses/templates/service.yaml
+++ b/k8s/plex/rreading-glasses/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "library.services" . -}}

--- a/k8s/plex/rreading-glasses/templates/serviceaccount.yaml
+++ b/k8s/plex/rreading-glasses/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.serviceAccount.create -}}
+{{- include "library.serviceaccount" (list . "rreading-glasses.serviceaccount") -}}
+{{- end -}}
+{{- define "rreading-glasses.serviceaccount" -}}
+{{- end -}}

--- a/k8s/plex/rreading-glasses/values.yaml
+++ b/k8s/plex/rreading-glasses/values.yaml
@@ -1,0 +1,105 @@
+# https://github.com/blampe/rreading-glasses
+# Self-hosted Readarr-compatible metadata server backed by Hardcover's
+# official API. Replaces the community proxy hardcover.bookinfo.pro that
+# bookshelf's hardcover build defaults to — that shared instance rate-limits
+# by IP (429s took bookshelf search down on 2026-08-22) while Drew's own
+# Hardcover quota sat idle. Image is distroless, runs as 65532 by design.
+# No ingress: only bookshelf talks to it, via the cluster service.
+replicaCount: 1
+
+image:
+  repository: docker.io/blampe/rreading-glasses
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ''
+
+imagePullSecrets: []
+nameOverride: ''
+fullnameOverride: ''
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ''
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+
+command: ["/main", "serve"]
+args: ["--verbose"]
+
+# Ports to be exposed, grouped by services
+services:
+  - name: http
+    type: ClusterIP
+    port: 8788
+    protocol: TCP
+
+# Upstream warns it will use all available memory for in-memory caching;
+# the limit is the cache ceiling, not a leak guard.
+resources:
+  requests:
+    cpu: 25m
+    memory: 128Mi
+  limits:
+    memory: 512Mi
+
+# HARDCOVER_AUTH ("Bearer <token>", expires every Jan 1 — see README) comes
+# from the out-of-band Secret rreading-glasses (key: hardcoverAuth).
+env:
+  - name: HARDCOVER_AUTH
+    valueFrom:
+      secretKeyRef:
+        name: rreading-glasses
+        key: hardcoverAuth
+
+# Key: value environment variables to be appended to env
+envVars:
+  TZ: America/New_York
+  POSTGRES_HOST: rreading-glasses-db-db
+  POSTGRES_DATABASE: rreading-glasses
+  POSTGRES_USER: rreading-glasses
+  POSTGRES_PASSWORD: rg-cache-n4Dp7qXe2w
+
+# Stateless; postgres holds the (rebuildable) cache.
+persistence: []
+
+nodeSelector: {}
+
+tolerations:
+  - key: compute
+    operator: Exists
+    effect: PreferNoSchedule
+
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: compute
+              operator: In
+              values:
+                - 'true'
+
+startupProbe:
+  tcpSocket:
+    port: 8788
+  failureThreshold: 30
+  periodSeconds: 10
+livenessProbe:
+  tcpSocket:
+    port: 8788
+readinessProbe:
+  tcpSocket:
+    port: 8788


### PR DESCRIPTION
Bookshelf search died on `hardcover.bookinfo.pro` 429s — the community metadata proxy its `hardcover` build is hardwired to rate-limits by IP, while Drew's own Hardcover API quota (5k/day) sits idle. [rreading-glasses](https://github.com/blampe/rreading-glasses) serves the same Readarr-compatible metadata API locally, backed by Hardcover's official API with our key.

**Two charts:**
- `rreading-glasses` — `blampe/rreading-glasses:hardcover`, distroless, runs as 65532 by design, cluster-internal only (no ingress; only bookshelf talks to it), memory-limited (upstream caches in RAM up to the limit)
- `rreading-glasses-db` — dedicated `postgres:18-alpine` cache DB, cloned from the bazarr-postgres pattern (uid 999, in-values creds for a rebuildable cluster-internal cache). **Gotcha fixed in the clone:** library-chart PVC names aren't release-prefixed, so the copied `postgres-data` claim would have collided with bazarr's — renamed.

**Trivy (flagging honestly):** 2 CRITICAL / 37 HIGH — all in the Go binary (`pgx` driver memory-safety, exploitable via a malicious *postgres server*, and ours is in-cluster; Go stdlib parsing, reachable only from bookshelf). No OS packages (distroless), no secrets. Rolling tag + pullPolicy Always picks up upstream rebuilds.

**Post-merge steps:**
1. Create a new Hardcover API key (don't reuse shelfmark's) and: `kubectl create secret generic rreading-glasses -n plex --from-literal=hardcoverAuth='Bearer <token>'` — note the key expires every Jan 1 per upstream
2. Sync both apps
3. Bookshelf → Settings → Development (advanced) → **Metadata Provider Source** → `http://plex-rreading-glasses-http:8788` → save, then re-test search