### PR TITLE
rreading-glasses: self-built image fixing Hardcover array-batching

### DIFF
--- a/.github/workflows/docker-rreading-glasses.yml
+++ b/.github/workflows/docker-rreading-glasses.yml
@@ -1,0 +1,48 @@
+name: Build and push rreading-glasses image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docker/rreading-glasses/**
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/rreading-glasses
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/rreading-glasses
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/rreading-glasses/Dockerfile
+++ b/docker/rreading-glasses/Dockerfile
@@ -1,0 +1,23 @@
+# rreading-glasses, patched to stop array-batching its Hardcover requests.
+#
+# Upstream (blampe/rreading-glasses) sends Hasura-style array-batched GraphQL
+# ([{query...}]) to Hardcover, which Hardcover's endpoint rejects with 400
+# "Unexpected end of document" — breaking every search and metadata lookup.
+# no-batch.patch swaps the batched client for the stock genqlient client
+# (one bare-object request per query). Verified end-to-end against the live
+# Hardcover API on 2026-08-22. See ../../k8s/plex/rreading-glasses/.
+#
+# Pinned to upstream commit a2939b6 ("decode search ids as int64", #549).
+FROM golang:1.26 AS build
+WORKDIR /src
+RUN git clone https://github.com/blampe/rreading-glasses.git . \
+    && git checkout a2939b625d91389d3f0a3e58cbc3bfa7ebb8390a
+COPY no-batch.patch .
+RUN git apply --verbose no-batch.patch
+RUN CGO_ENABLED=0 go build -trimpath -o /main ./cmd/rghc
+
+FROM gcr.io/distroless/static:nonroot
+COPY --from=build /main /main
+USER 65532:65532
+EXPOSE 8788
+ENTRYPOINT ["/main"]

--- a/docker/rreading-glasses/README.md
+++ b/docker/rreading-glasses/README.md
@@ -1,0 +1,37 @@
+# rreading-glasses (patched)
+
+Custom build of [blampe/rreading-glasses](https://github.com/blampe/rreading-glasses),
+the Readarr-compatible metadata server, used by Bookshelf in the plex
+namespace so book searches use our own Hardcover API quota instead of the
+shared `hardcover.bookinfo.pro` proxy (which rate-limited us to death).
+
+## Why the patch
+
+Upstream's GraphQL client batches requests **Hasura-style**: it sends a JSON
+array `[{query, variables}]` and expects an array response. Hardcover's
+`api.hardcover.app/v1/graphql` does **not** accept array-batched requests —
+it returns `400 Bad Request` / `"Unexpected end of document"` — so every
+search and metadata lookup fails with a 400 the UI surfaces as
+"unexpected token '<'… is not valid JSON".
+
+Diagnosed by MITM-capturing the exact outbound request (2026-08-22): the
+identical query as a bare object returns `200`; wrapped in a one-element
+array it returns `400`. `no-batch.patch` makes `NewBatchedGraphQLClient`
+return the stock genqlient client, which sends one bare-object request per
+query. Verified end-to-end against the live Hardcover API — search returns
+real results.
+
+**Trade-off:** no request batching means more calls to Hardcover. Their free
+tier is 60/min + burst 10, ample for a home library, and rreading-glasses
+caches everything in Postgres so each author/work is fetched once. Heavy
+first-time author fanouts can still transiently hit 429; they resolve on
+retry as the cache warms.
+
+## Maintenance
+
+Pinned to upstream commit `a2939b6`. To bump: change the SHA in the
+Dockerfile, re-run `git apply` locally against the new tree, refresh the
+patch if the anchor moved, and push (the workflow rebuilds and pushes
+`ghcr.io/drewburr-labs/rreading-glasses:latest`). If upstream fixes the
+batching (track issues #574/#576), drop this image and point the chart back
+at `blampe/rreading-glasses:hardcover`.

--- a/docker/rreading-glasses/no-batch.patch
+++ b/docker/rreading-glasses/no-batch.patch
@@ -1,0 +1,23 @@
+diff --git a/internal/graphql.go b/internal/graphql.go
+index fa3a870..3d7e8c9 100644
+--- a/internal/graphql.go
++++ b/internal/graphql.go
+@@ -40,6 +40,18 @@ type batchedgqlclient struct {
+ // NewBatchedGraphQLClient creates a batching GraphQL client. Queries are
+ // accumulated and executed regularly accurding to the given rate.
+ func NewBatchedGraphQLClient(url string, client *http.Client, every time.Duration, batchSize int, reg *prometheus.Registry) (graphql.Client, error) {
++	// PATCH (drewburr-labs): Hardcover's GraphQL endpoint rejects the
++	// Hasura-style array-batched request this client sends ([{query...}])
++	// with 400 "Unexpected end of document", breaking all lookups. Use the
++	// stock genqlient client (one bare-object request per query). Hardcover's
++	// rate limit is ample for a home library; results cache in Postgres.
++	if true {
++		_ = every
++		_ = batchSize
++		_ = reg
++		return graphql.NewClient(url, client), nil
++	}
++
+ 	wrapped := graphql.NewClient(url, client)
+ 
+ 	c := &batchedgqlclient{

--- a/k8s/plex/rreading-glasses/values.yaml
+++ b/k8s/plex/rreading-glasses/values.yaml
@@ -1,17 +1,19 @@
-# https://github.com/blampe/rreading-glasses
-# Self-hosted Readarr-compatible metadata server backed by Hardcover's
-# official API. Replaces the community proxy hardcover.bookinfo.pro that
-# bookshelf's hardcover build defaults to — that shared instance rate-limits
-# by IP (429s took bookshelf search down on 2026-08-22) while Drew's own
-# Hardcover quota sat idle. Image is distroless, runs as 65532 by design.
+# Self-hosted Readarr-compatible metadata server (blampe/rreading-glasses)
+# backed by Hardcover's official API, so bookshelf uses our own Hardcover
+# quota instead of the shared hardcover.bookinfo.pro proxy (which
+# rate-limited bookshelf search to death on 2026-08-22).
+#
+# We build our OWN image (docker/rreading-glasses) because upstream sends
+# Hasura-style array-batched GraphQL that Hardcover rejects with 400,
+# breaking all lookups — the patch un-batches it. Distroless, runs as 65532.
 # No ingress: only bookshelf talks to it, via the cluster service.
 replicaCount: 1
 
 image:
-  repository: docker.io/blampe/rreading-glasses
+  repository: ghcr.io/drewburr-labs/rreading-glasses
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ''
+  tag: 'latest'
 
 imagePullSecrets: []
 nameOverride: ''


### PR DESCRIPTION
**Bookshelf search was 400ing** through rreading-glasses. Root cause, captured on the wire (MITM of the outbound request 2026-08-22): upstream batches GraphQL Hasura-style — sends `[{query,variables}]` and expects an array response — but Hardcover's `api.hardcover.app/v1/graphql` doesn't accept array-batched requests and returns `400 'Unexpected end of document'`. The **identical query as a bare object returns 200** (proven repeatedly against the live API).

**Fix:** `docker/rreading-glasses/no-batch.patch` makes `NewBatchedGraphQLClient` return the stock genqlient client (one bare-object request per query). Built and tested end-to-end on the final distroless image — search returns real results, runs as 65532 nonroot.

Packaged in the **docker/plex self-maintained-image pattern**: pinned upstream commit `a2939b6` + patch + `.github/workflows/docker-rreading-glasses.yml` pushing `ghcr.io/drewburr-labs/rreading-glasses:latest`. Chart repointed off `docker.io/blampe`.

**Trade-off (honest):** no request batching → more calls to Hardcover. Free tier is 60/min + burst 10, ample for a home library, and everything caches in Postgres so each author/work is fetched once. Heavy first-time fanouts can transiently 429 and resolve on retry (also aggravated today by all the diagnostic traffic).

**Merge ordering:** the workflow builds the image on merge (paths filter on `docker/rreading-glasses/**`). Let it finish and confirm the package is published/visible before syncing `plex-rreading-glasses`, else the pod will ImagePullBackOff until it lands. Then the pod pulls the fixed image; Bookshelf search works with no further config (metadata source already points at `plex-rreading-glasses-http:8788`).