### PR TITLE
rreading-glasses: throttle un-batched client (fix 429 empty-results)

### DIFF
--- a/docker/rreading-glasses/README.md
+++ b/docker/rreading-glasses/README.md
@@ -16,16 +16,26 @@ search and metadata lookup fails with a 400 the UI surfaces as
 
 Diagnosed by MITM-capturing the exact outbound request (2026-08-22): the
 identical query as a bare object returns `200`; wrapped in a one-element
-array it returns `400`. `no-batch.patch` makes `NewBatchedGraphQLClient`
-return the stock genqlient client, which sends one bare-object request per
-query. Verified end-to-end against the live Hardcover API — search returns
-real results.
+array it returns `400`. Hardcover also caps any request at **5 top-level
+queries** (`403` over that, per their rate-limit docs), so upstream merging
+up to 25 into one request is doubly incompatible.
 
-**Trade-off:** no request batching means more calls to Hardcover. Their free
-tier is 60/min + burst 10, ample for a home library, and rreading-glasses
-caches everything in Postgres so each author/work is fetched once. Heavy
-first-time author fanouts can still transiently hit 429; they resolve on
-retry as the cache warms.
+`no-batch.patch` makes `NewBatchedGraphQLClient` return the stock genqlient
+client (one bare-object query per request) **and** throttles it to
+Hardcover's 60/min via the codebase's existing `throttledTransport`. The
+throttle is essential, not cosmetic: without batching, a single search fans
+out ~20-40 concurrent work/edition fetches, instantly blows Hardcover's
+burst bucket, every sub-fetch `429`s, and the results all get dropped —
+searches return `[]` with a misleading `200`. Verified end-to-end against
+the live API: search returns real results with **zero 429s** across the
+fanout.
+
+**Trade-off:** throttling paces cold lookups at ~1/sec, so the first fetch
+of a large author can take tens of seconds. Everything caches in Postgres,
+so it's a one-time cost per work/author. Hardcover's per-minute limit is 60
+regardless of plan, so 1/sec is the safe sustained ceiling; a Supporter
+plan raises the daily limit (50k) and burst (15) but not the sustained
+rate.
 
 ## Maintenance
 

--- a/docker/rreading-glasses/no-batch.patch
+++ b/docker/rreading-glasses/no-batch.patch
@@ -1,21 +1,32 @@
 diff --git a/internal/graphql.go b/internal/graphql.go
-index fa3a870..3d7e8c9 100644
+index fa3a870..5505dac 100644
 --- a/internal/graphql.go
 +++ b/internal/graphql.go
-@@ -40,6 +40,18 @@ type batchedgqlclient struct {
+@@ -40,6 +40,29 @@ type batchedgqlclient struct {
  // NewBatchedGraphQLClient creates a batching GraphQL client. Queries are
  // accumulated and executed regularly accurding to the given rate.
  func NewBatchedGraphQLClient(url string, client *http.Client, every time.Duration, batchSize int, reg *prometheus.Registry) (graphql.Client, error) {
-+	// PATCH (drewburr-labs): Hardcover's GraphQL endpoint rejects the
-+	// Hasura-style array-batched request this client sends ([{query...}])
-+	// with 400 "Unexpected end of document", breaking all lookups. Use the
-+	// stock genqlient client (one bare-object request per query). Hardcover's
-+	// rate limit is ample for a home library; results cache in Postgres.
++	// PATCH (drewburr-labs): Hardcover rejects this client's Hasura-style
++	// array-batched requests (400) and caps ANY request at 5 top-level
++	// queries (403 over that); upstream merges up to 25, so batching is
++	// doubly incompatible. Send one bare-object query per request (stock
++	// genqlient) and throttle to Hardcover's 60/min so the concurrent work
++	// fanout stays under the burst bucket instead of 429ing and dropping
++	// every result. Cold lookups are paced ~1/sec; results cache in
++	// Postgres so this only bites the first fetch of a given work/author.
 +	if true {
 +		_ = every
 +		_ = batchSize
 +		_ = reg
-+		return graphql.NewClient(url, client), nil
++		rt := client.Transport
++		if rt == nil {
++			rt = http.DefaultTransport
++		}
++		throttled := &http.Client{
++			Transport:     throttledTransport{RoundTripper: rt, ticker: time.NewTicker(time.Second)},
++			CheckRedirect: client.CheckRedirect,
++		}
++		return graphql.NewClient(url, throttled), nil
 +	}
 +
  	wrapped := graphql.NewClient(url, client)


### PR DESCRIPTION
Follow-up to #34. That un-batch fixed the `400`/`403` (Hardcover rejects array batching and caps requests at 5 top-level queries), and searches returned `200` — but **empty**. Root cause, confirmed against the live API: without batching, a single search fans out ~20-40 concurrent work/edition fetches, which blows Hardcover's **burst bucket** (10 free / 15 Supporter); every sub-fetch `429`s and the results get dropped, yielding `[]` with a misleading `200`.

Verified with a burst probe: requests 1-9 succeed, 10+ `429` — a per-minute/burst limit, not the daily quota.

**Fix:** wrap the un-batched Hardcover client in the codebase's own `throttledTransport` at 60/min (Hardcover's per-minute limit on *every* plan — the fixed ceiling). Now the concurrent fanout is paced under the burst bucket. Built and tested end-to-end on the final image: **search returns real results, zero 429s across the fanout.**

**Trade-off:** cold lookups pace at ~1/sec, so the first fetch of a large author takes tens of seconds; everything then caches in Postgres (one-time cost). Supporter's higher daily/burst helps headroom but the 60/min sustained rate is plan-independent, so 1/sec stays the safe pace.

Merge → workflow rebuilds `ghcr.io/drewburr-labs/rreading-glasses:latest` → sync/restart `plex-rreading-glasses`. Then Bookshelf search returns real results (first search of an author may be slow, then instant).